### PR TITLE
Abstract method interface change

### DIFF
--- a/src/main/java/com/nexmo/client/HttpWrapper.java
+++ b/src/main/java/com/nexmo/client/HttpWrapper.java
@@ -22,7 +22,10 @@ package com.nexmo.client;/*
 
 import com.nexmo.client.auth.AuthCollection;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
@@ -60,15 +63,25 @@ public class HttpWrapper {
     }
 
     protected HttpClient createHttpClient() {
-        ThreadSafeClientConnManager threadSafeClientConnManager = new ThreadSafeClientConnManager();
+        PoolingHttpClientConnectionManager threadSafeClientConnManager = new PoolingHttpClientConnectionManager();
         threadSafeClientConnManager.setDefaultMaxPerRoute(200);
         threadSafeClientConnManager.setMaxTotal(200);
+        // threadSafeClientConnManager.setValidateAfterInactivity();
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .build();
+
+
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create()
+                .setUserAgent("nexmo-java/2.0.0-prerelease")
+                .setDefaultRequestConfig();
+
 
         HttpParams httpClientParams = new BasicHttpParams();
-        HttpProtocolParams.setUserAgent(httpClientParams, "nexmo-java/2.0.0-prerelease");
+        // HttpProtocolParams.setUserAgent(httpClientParams, );
         HttpProtocolParams.setContentCharset(httpClientParams, "UTF-8");
         HttpProtocolParams.setHttpElementCharset(httpClientParams, "UTF-8");
-        HttpConnectionParams.setStaleCheckingEnabled(httpClientParams, true);
+        // HttpConnectionParams.setStaleCheckingEnabled(httpClientParams, true);
         HttpConnectionParams.setTcpNoDelay(httpClientParams, true);
 
         return new DefaultHttpClient(threadSafeClientConnManager, httpClientParams);

--- a/src/main/java/com/nexmo/client/HttpWrapper.java
+++ b/src/main/java/com/nexmo/client/HttpWrapper.java
@@ -23,6 +23,8 @@ package com.nexmo.client;/*
 import com.nexmo.client.auth.AuthCollection;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.config.ConnectionConfig;
+import org.apache.http.config.SocketConfig;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -31,6 +33,8 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
+
+import java.nio.charset.Charset;
 
 /**
  * Internal class that holds available authentication methods and a shared HttpClient.
@@ -63,27 +67,22 @@ public class HttpWrapper {
     }
 
     protected HttpClient createHttpClient() {
-        PoolingHttpClientConnectionManager threadSafeClientConnManager = new PoolingHttpClientConnectionManager();
-        threadSafeClientConnManager.setDefaultMaxPerRoute(200);
-        threadSafeClientConnManager.setMaxTotal(200);
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setDefaultMaxPerRoute(200);
+        connectionManager.setMaxTotal(200);
+        connectionManager.setDefaultConnectionConfig(
+                ConnectionConfig.custom().setCharset(Charset.forName("UTF-8")).build());
+        connectionManager.setDefaultSocketConfig(SocketConfig.custom().setTcpNoDelay(true).build());
+
+        // Need to work out a good value for the following:
         // threadSafeClientConnManager.setValidateAfterInactivity();
 
-        RequestConfig requestConfig = RequestConfig.custom()
-                .build();
+        RequestConfig requestConfig = RequestConfig.custom().build();
 
-
-        HttpClientBuilder clientBuilder = HttpClientBuilder.create()
+        return HttpClientBuilder.create()
+                .setConnectionManager(connectionManager)
                 .setUserAgent("nexmo-java/2.0.0-prerelease")
-                .setDefaultRequestConfig();
-
-
-        HttpParams httpClientParams = new BasicHttpParams();
-        // HttpProtocolParams.setUserAgent(httpClientParams, );
-        HttpProtocolParams.setContentCharset(httpClientParams, "UTF-8");
-        HttpProtocolParams.setHttpElementCharset(httpClientParams, "UTF-8");
-        // HttpConnectionParams.setStaleCheckingEnabled(httpClientParams, true);
-        HttpConnectionParams.setTcpNoDelay(httpClientParams, true);
-
-        return new DefaultHttpClient(threadSafeClientConnManager, httpClientParams);
+                .setDefaultRequestConfig(requestConfig)
+                .build();
     }
 }

--- a/src/main/java/com/nexmo/client/auth/AuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/AuthMethod.java
@@ -20,11 +20,11 @@ package com.nexmo.client.auth;/*
  * THE SOFTWARE.
  */
 
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 
 
 public interface AuthMethod extends Comparable<AuthMethod> {
-    public HttpUriRequest apply(HttpUriRequest request);
+    public RequestBuilder apply(RequestBuilder request);
 
     public int getSortKey();
 }

--- a/src/main/java/com/nexmo/client/auth/JWTAuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/JWTAuthMethod.java
@@ -23,7 +23,7 @@ package com.nexmo.client.auth;/*
 import com.auth0.jwt.Algorithm;
 import com.auth0.jwt.JWTSigner;
 import com.nexmo.client.NexmoUnexpectedException;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 
 import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
@@ -88,7 +88,7 @@ public class JWTAuthMethod extends AbstractAuthMethod {
     }
 
     @Override
-    public HttpUriRequest apply(HttpUriRequest request) {
+    public RequestBuilder apply(RequestBuilder request) {
         String token = this.constructToken(
                 System.currentTimeMillis() / 1000L,
                 constructJTI());

--- a/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
@@ -21,13 +21,13 @@ package com.nexmo.client.auth;/*
  */
 
 
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 
 public class TokenAuthMethod extends AbstractAuthMethod {
     public final int SORT_KEY = 20;
 
     @Override
-    public HttpUriRequest apply(HttpUriRequest request) {
+    public RequestBuilder apply(RequestBuilder request) {
         // FIXME: This is a stub.
         return request;
     }

--- a/src/main/java/com/nexmo/client/voice/SendDTMFMethod.java
+++ b/src/main/java/com/nexmo/client/voice/SendDTMFMethod.java
@@ -27,8 +27,7 @@ import com.nexmo.client.voice.endpoints.AbstractMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 
@@ -52,13 +51,11 @@ public class SendDTMFMethod extends AbstractMethod<DTMFRequest, DTMFResponse> {
     }
 
     @Override
-    public HttpUriRequest makeRequest(DTMFRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(DTMFRequest request) throws NexmoClientException, UnsupportedEncodingException {
         String uri = this.uri + request.getUuid() + "/dtmf";
-        HttpPut put = new HttpPut(uri);
-        put.setHeader("Content-Type", "application/json");
-        put.setEntity(new StringEntity(request.toJson()));
-        LOG.info("Request: " + request.toJson());
-        return put;
+        return RequestBuilder.put(uri)
+                .setHeader("Content-Type", "application/json")
+                .setEntity(new StringEntity(request.toJson()));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/StartTalkMethod.java
+++ b/src/main/java/com/nexmo/client/voice/StartTalkMethod.java
@@ -27,8 +27,7 @@ import com.nexmo.client.voice.endpoints.AbstractMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 
@@ -52,14 +51,11 @@ public class StartTalkMethod extends AbstractMethod<TalkRequest, TalkResponse> {
     }
 
     @Override
-    public HttpUriRequest makeRequest(TalkRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(TalkRequest request) throws NexmoClientException, UnsupportedEncodingException {
         String uri = this.uri + request.getUuid() + "/talk";
-        HttpPut put = new HttpPut(uri);
-        put.setHeader("Content-Type", "application/json");
-        put.setEntity(new StringEntity(request.toJson()));
-        LOG.info("Request: " + request.toJson());
-
-        return put;
+        return RequestBuilder.put(uri)
+                .setHeader("Content-Type", "application/json")
+                .setEntity(new StringEntity(request.toJson()));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/StopTalkMethod.java
+++ b/src/main/java/com/nexmo/client/voice/StopTalkMethod.java
@@ -27,8 +27,7 @@ import com.nexmo.client.voice.endpoints.AbstractMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
@@ -51,12 +50,10 @@ public class StopTalkMethod extends AbstractMethod<String, TalkResponse> {
     }
 
     @Override
-    public HttpUriRequest makeRequest(String uuid) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(String uuid) throws NexmoClientException, UnsupportedEncodingException {
         String uri = this.uri + uuid + "/talk";
-        HttpDelete delete = new HttpDelete(uri);
-        delete.setHeader("Content-Type", "application/json");
-        LOG.info("StopTalkRequest made for" + uuid);
-        return delete;
+        return RequestBuilder.delete(uri)
+                .setHeader("Content-Type", "application/json");
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -47,7 +48,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
     // TODO: Consider wrapping IOException in a nexmo-specific transport exception.
     public ResultT execute(RequestT request) throws IOException, NexmoClientException {
         try {
-            HttpResponse response = this.httpWrapper.getHttpClient().execute(applyAuth(makeRequest(request)));
+            HttpResponse response = this.httpWrapper.getHttpClient().execute(applyAuth(makeRequest(request)).build());
             LOG.debug("Response: " + response.getStatusLine());
             return parseResponse(response);
         } catch (UnsupportedEncodingException uee) {
@@ -55,7 +56,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
         }
     }
 
-    protected HttpUriRequest applyAuth(HttpUriRequest request) throws NexmoClientException {
+    protected RequestBuilder applyAuth(RequestBuilder request) throws NexmoClientException {
         return getAuthMethod(getAcceptableAuthMethods()).apply(request);
     }
 
@@ -84,8 +85,8 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
 
     protected abstract Class[] getAcceptableAuthMethods();
 
-    public abstract HttpUriRequest makeRequest(RequestT request) throws NexmoClientException,
-            UnsupportedEncodingException;
+    public abstract RequestBuilder makeRequest(RequestT request)
+            throws NexmoClientException, UnsupportedEncodingException;
 
     public abstract ResultT parseResponse(HttpResponse response) throws IOException;
 }

--- a/src/main/java/com/nexmo/client/voice/endpoints/CreateCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/CreateCallMethod.java
@@ -28,8 +28,7 @@ import com.nexmo.client.voice.CallEvent;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 
@@ -48,13 +47,11 @@ public class CreateCallMethod extends AbstractMethod<Call, CallEvent> {
     }
 
     @Override
-    public HttpUriRequest makeRequest(Call request) throws NexmoClientException, UnsupportedEncodingException {
-        HttpPost post = new HttpPost(this.uri);
-        post.setHeader("Content-Type", "application/json");
-        post.setEntity(new StringEntity(request.toJson()));
-        LOG.info("Request: " + request.toJson());
-
-        return post;
+    public RequestBuilder makeRequest(Call request) throws NexmoClientException, UnsupportedEncodingException {
+        return RequestBuilder
+                .post(this.uri)
+                .setHeader("Content-Type", "application/json")
+                .setEntity(new StringEntity(request.toJson()));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/endpoints/ListCallsMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/ListCallsMethod.java
@@ -31,8 +31,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.util.EntityUtils;
 
@@ -58,7 +57,7 @@ public class ListCallsMethod extends AbstractMethod<CallsFilter, CallRecordPage>
     }
 
     @Override
-    public HttpUriRequest makeRequest(CallsFilter filter) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(CallsFilter filter) throws NexmoClientException, UnsupportedEncodingException {
         URIBuilder uriBuilder;
         try {
             uriBuilder = new URIBuilder(this.uri);
@@ -71,9 +70,7 @@ public class ListCallsMethod extends AbstractMethod<CallsFilter, CallRecordPage>
                 uriBuilder.setParameter(param.getName(), param.getValue());
             }
         }
-        HttpUriRequest request = new HttpGet(uriBuilder.toString());
-        LOG.debug("List Calls request: " + request.getURI());
-        return request;
+        return RequestBuilder.get().setUri(uriBuilder.toString());
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/endpoints/ModifyCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/ModifyCallMethod.java
@@ -28,8 +28,7 @@ import com.nexmo.client.voice.CallRecord;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 
@@ -54,13 +53,12 @@ public class ModifyCallMethod extends AbstractMethod<CallModifier, CallRecord> {
     }
 
     @Override
-    public HttpUriRequest makeRequest(CallModifier request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(CallModifier request) throws NexmoClientException, UnsupportedEncodingException {
         String uri = this.uri + request.getUuid();
-        HttpPut put = new HttpPut(uri);
-        put.setHeader("Content-Type", "application/json");
-        put.setEntity(new StringEntity(request.toJson()));
-        LOG.info("Request: " + request.toJson());
-        return put;
+        return RequestBuilder
+                .put(uri)
+                .setHeader("Content-Type", "application/json")
+                .setEntity(new StringEntity(request.toJson()));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/endpoints/ReadCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/ReadCallMethod.java
@@ -26,8 +26,7 @@ import com.nexmo.client.voice.CallRecord;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
@@ -50,11 +49,9 @@ public class ReadCallMethod extends AbstractMethod<String, CallRecord> {
     }
 
     @Override
-    public HttpUriRequest makeRequest(String callId) {
+    public RequestBuilder makeRequest(String callId) {
         String uri = this.baseUri + callId;
-        HttpGet result = new HttpGet(uri);
-
-        return result;
+        return RequestBuilder.get(uri);
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/endpoints/StartStreamMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/StartStreamMethod.java
@@ -28,8 +28,7 @@ import com.nexmo.client.voice.StreamResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 
@@ -53,14 +52,11 @@ public class StartStreamMethod extends AbstractMethod<StreamRequest, StreamRespo
     }
 
     @Override
-    public HttpUriRequest makeRequest(StreamRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(StreamRequest request) throws NexmoClientException, UnsupportedEncodingException {
         String uri = this.uri + request.getUuid() + "/stream";
-        HttpPut put = new HttpPut(uri);
-        put.setHeader("Content-Type", "application/json");
-        put.setEntity(new StringEntity(request.toJson()));
-        LOG.info("Request: " + request.toJson());
-
-        return put;
+        return RequestBuilder.put(uri)
+                .setHeader("Content-Type", "application/json")
+                .setEntity(new StringEntity(request.toJson()));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/endpoints/StopStreamMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/StopStreamMethod.java
@@ -28,7 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
@@ -51,12 +51,10 @@ public class StopStreamMethod extends AbstractMethod<String, StreamResponse> {
     }
 
     @Override
-    public HttpUriRequest makeRequest(String uuid) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(String uuid) throws NexmoClientException, UnsupportedEncodingException {
         String uri = this.uri + uuid + "/stream";
-        HttpDelete delete = new HttpDelete(uri);
-        delete.setHeader("Content-Type", "application/json");
-        LOG.info("StopStreamRequest made for " + uuid);
-        return delete;
+        return RequestBuilder.delete(uri)
+                .setHeader("Content-Type", "application/json");
     }
 
     @Override

--- a/src/test/java/com/nexmo/client/auth/JWTAuthMethodTest.java
+++ b/src/test/java/com/nexmo/client/auth/JWTAuthMethodTest.java
@@ -24,8 +24,7 @@ package com.nexmo.client.auth;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.JWTVerifyException;
 import com.nexmo.client.TestUtils;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -72,7 +71,7 @@ public class JWTAuthMethodTest {
     @Test
     public void testDecodePrivateKeyInvalid() throws Exception {
         try {
-            auth = new JWTAuthMethod("application-id", new byte[] { 0x00 });
+            auth = new JWTAuthMethod("application-id", new byte[]{0x00});
             fail("Invalid bytes should result in InvalidKeySpecException");
         } catch (InvalidKeySpecException e) {
             // this is expected
@@ -82,7 +81,7 @@ public class JWTAuthMethodTest {
     @Test
     public void testDecodePrivateKeyCannotDecode() throws Exception {
         try {
-            auth = new JWTAuthMethod("application-id", new byte[] { '-' });
+            auth = new JWTAuthMethod("application-id", new byte[]{'-'});
             fail("Invalid key should result in InvalidKeySpecException");
         } catch (InvalidKeyException e) {
             // this is expected
@@ -91,7 +90,7 @@ public class JWTAuthMethodTest {
 
     @Test
     public void testApply() throws Exception {
-        HttpUriRequest req = new HttpGet();
+        RequestBuilder req = RequestBuilder.get();
         auth.apply(req);
 
         assertEquals(1, req.getHeaders("Authorization").length);

--- a/src/test/java/com/nexmo/client/voice/NexmoVoiceClientTest.java
+++ b/src/test/java/com/nexmo/client/voice/NexmoVoiceClientTest.java
@@ -306,6 +306,5 @@ public class NexmoVoiceClientTest {
         TalkResponse response = client.stopTalk("ssf61863-4a51-ef6b-11e1-w6edebcf93bb");
         assertEquals("Talk stopped", response.getMessage());
         assertEquals("ssf61863-4a51-ef6b-11e1-w6edebcf93bb", response.getUuid());
-
     }
 }

--- a/src/test/java/com/nexmo/client/voice/SendDTMFMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/SendDTMFMethodTest.java
@@ -7,8 +7,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
@@ -49,17 +48,16 @@ public class SendDTMFMethodTest {
         HttpWrapper httpWrapper = new HttpWrapper(null);
         SendDTMFMethod methodUnderTest = new SendDTMFMethod(httpWrapper);
 
-        HttpUriRequest request = methodUnderTest.makeRequest(
+        RequestBuilder request = methodUnderTest.makeRequest(
                 new DTMFRequest("abc-123", "867")
         );
 
-        assertEquals(HttpPut.class, request.getClass());
+        assertEquals("PUT", request.getMethod());
         assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
-        HttpPut putRequest = (HttpPut) request;
 
         ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode node = objectMapper.readValue(putRequest.getEntity().getContent(), JsonNode.class);
-        LOG.info(putRequest.getEntity().getContent());
+        JsonNode node = objectMapper.readValue(request.getEntity().getContent(), JsonNode.class);
+        LOG.info(request.getEntity().getContent());
         assertEquals("867", node.get("digits").asText());
     }
 
@@ -69,7 +67,7 @@ public class SendDTMFMethodTest {
         SendDTMFMethod methodUnderTest = new SendDTMFMethod(wrapper);
 
         HttpResponse stubResponse = new BasicHttpResponse(
-                new BasicStatusLine(new ProtocolVersion("1.1", 1,1), 200, "OK")
+                new BasicStatusLine(new ProtocolVersion("1.1", 1, 1), 200, "OK")
         );
 
         String json = "{\"message\": \"DTMF sent\",\"uuid\": \"ssf61863-4a51-ef6b-11e1-w6edebcf93bb\"}";

--- a/src/test/java/com/nexmo/client/voice/endpoints/AbstractMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/AbstractMethodTest.java
@@ -9,8 +9,8 @@ import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.Before;
@@ -33,12 +33,12 @@ public class AbstractMethodTest {
 
         @Override
         protected Class[] getAcceptableAuthMethods() {
-            return new Class[]{ JWTAuthMethod.class };
+            return new Class[]{JWTAuthMethod.class};
         }
 
         @Override
-        public HttpUriRequest makeRequest(String request) throws NexmoClientException, UnsupportedEncodingException {
-            return new HttpGet(request);
+        public RequestBuilder makeRequest(String request) throws NexmoClientException, UnsupportedEncodingException {
+            return RequestBuilder.get(request);
         }
 
         @Override
@@ -88,7 +88,7 @@ public class AbstractMethodTest {
     public void testApplyAuth() throws Exception {
         ConcreteMethod method = new ConcreteMethod(mockWrapper);
 
-        HttpUriRequest request = new HttpGet("url");
+        RequestBuilder request = RequestBuilder.get("url");
         method.applyAuth(request);
         verify(mockAuthMethod).apply(request);
     }

--- a/src/test/java/com/nexmo/client/voice/endpoints/CreateCallMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/CreateCallMethodTest.java
@@ -33,8 +33,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
@@ -54,16 +53,15 @@ public class CreateCallMethodTest {
         CreateCallMethod methodUnderTest = new CreateCallMethod(null);
 
         // Execute test call:
-        HttpUriRequest request = methodUnderTest.makeRequest(
+        RequestBuilder request = methodUnderTest.makeRequest(
                 new Call("447700900903", "447700900904", "https://example.com/answer"));
 
-        assertEquals(HttpPost.class, request.getClass());
+        assertEquals("POST", request.getMethod());
         assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
-        HttpPost postRequest = (HttpPost) request;
 
         ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode node =  objectMapper.readValue(postRequest.getEntity().getContent(), JsonNode.class);
-        LOG.info(postRequest.getEntity().getContent());
+        JsonNode node = objectMapper.readValue(request.getEntity().getContent(), JsonNode.class);
+        LOG.info(request.getEntity().getContent());
         assertEquals("447700900903", node.get("to").get(0).get("number").asText());
         assertEquals("447700900904", node.get("from").get("number").asText());
         assertEquals("https://example.com/answer", node.get("answer_url").get(0).asText());
@@ -73,9 +71,9 @@ public class CreateCallMethodTest {
     public void testCustomUri() throws Exception {
         CreateCallMethod methodUnderTest = new CreateCallMethod(null);
         methodUnderTest.setUri("https://api.example.com/calls");
-        HttpUriRequest request = methodUnderTest.makeRequest(
+        RequestBuilder request = methodUnderTest.makeRequest(
                 new Call("447700900903", "447700900904", "https://example.com/answer"));
-        assertEquals("https://api.example.com/calls", request.getURI().toString());
+        assertEquals("https://api.example.com/calls", request.getUri().toString());
     }
 
     @Test

--- a/src/test/java/com/nexmo/client/voice/endpoints/ListCallsMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ListCallsMethodTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
@@ -41,9 +41,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class ListCallsMethodTest {
     private static final Log LOG = LogFactory.getLog(ListCallsMethodTest.class);
@@ -63,18 +61,18 @@ public class ListCallsMethodTest {
 
     @Test
     public void makeRequestWithNoFilter() throws Exception {
-        HttpUriRequest request = method.makeRequest(null);
+        RequestBuilder request = method.makeRequest(null);
         assertEquals("GET", request.getMethod());
-        assertEquals("https://api.nexmo.com/v1/calls", request.getURI().toString());
+        assertEquals("https://api.nexmo.com/v1/calls", request.getUri().toString());
     }
 
     @Test
     public void makeRequestWithFilter() throws Exception {
         CallsFilter callsFilter = new CallsFilter();
         callsFilter.setPageSize(3);
-        HttpUriRequest request = method.makeRequest(callsFilter);
+        RequestBuilder request = method.makeRequest(callsFilter);
         assertEquals("GET", request.getMethod());
-        assertEquals("https://api.nexmo.com/v1/calls?page_size=3", request.getURI().toString());
+        assertEquals("https://api.nexmo.com/v1/calls?page_size=3", request.getUri().toString());
     }
 
     @Test
@@ -172,9 +170,9 @@ public class ListCallsMethodTest {
         try {
             CallsFilter filter = new CallsFilter();
             filter.setPageSize(30);
-            HttpUriRequest request = method.makeRequest(filter);
+            RequestBuilder request = method.makeRequest(filter);
             // Anything past here only executes if our assertion is incorrect:
-            LOG.error("Request URI: " + request.getURI());
+            LOG.error("Request URI: " + request.getUri());
             fail("Making a request with a bad URI should throw a NexmoUnexpectedException");
         } catch (NexmoUnexpectedException nue) {
             // This is expected

--- a/src/test/java/com/nexmo/client/voice/endpoints/ModifyCallMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ModifyCallMethodTest.java
@@ -11,8 +11,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
@@ -53,17 +52,16 @@ public class ModifyCallMethodTest {
         HttpWrapper httpWrapper = new HttpWrapper(null);
         ModifyCallMethod methodUnderTest = new ModifyCallMethod(httpWrapper);
 
-        HttpUriRequest request = methodUnderTest.makeRequest(
+        RequestBuilder request = methodUnderTest.makeRequest(
                 new CallModifier("abc-123", "hangup")
         );
 
-        assertEquals(HttpPut.class, request.getClass());
+        assertEquals("PUT", request.getMethod());
         assertEquals("application/json", request.getFirstHeader("Content-Type").getValue());
-        HttpPut putRequest = (HttpPut) request;
 
         ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode node = objectMapper.readValue(putRequest.getEntity().getContent(), JsonNode.class);
-        LOG.info(putRequest.getEntity().getContent());
+        JsonNode node = objectMapper.readValue(request.getEntity().getContent(), JsonNode.class);
+        LOG.info(request.getEntity().getContent());
         assertEquals("hangup", node.get("action").asText());
     }
 

--- a/src/test/java/com/nexmo/client/voice/endpoints/ReadCallMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ReadCallMethodTest.java
@@ -27,6 +27,7 @@ import com.nexmo.client.voice.CallRecord;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
@@ -55,8 +56,8 @@ public class ReadCallMethodTest {
 
     @Test
     public void makeRequest() throws Exception {
-        HttpUriRequest request = method.makeRequest("abcd-efgh");
-        assertEquals("https://api.nexmo.com/v1/calls/abcd-efgh", request.getURI().toString());
+        RequestBuilder request = method.makeRequest("abcd-efgh");
+        assertEquals("https://api.nexmo.com/v1/calls/abcd-efgh", request.getUri().toString());
     }
 
     @Test


### PR DESCRIPTION
Needed to replace `HttpUriRequest` with `RequestBuilder` in AbstractMethod because other auth methods need to change things other than just headers (and HttpUriRequest is almost immutable).