### PR TITLE
Fix import statements so example will compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ The following code initiates an outbound call which then reads the user [a messa
 ```java
 import java.nio.file.Paths;
 
+import com.nexmo.client.NexmoClient;
 import com.nexmo.client.auth.JWTAuthMethod;
-import com.nexmo.client.voice.NexmoClient;
 import com.nexmo.client.voice.Call;
+import com.nexmo.client.voice.CallEvent;
 
 JWTAuthMethod auth = new JWTAuthMethod(application_id, Paths.get("application_key.pem"));
 NexmoClient client = new NexmoClient(auth);


### PR DESCRIPTION
* Existing import statement for `NexmoClient` was incorrect.
* Missing import statement for `CallEvent`

To reduce the chances of this happening I'd recommend creating a quickstart repository and ensure examples are copied/pasted from code examples that compile.
