### PR TITLE
Implement cnam parameter for Number Insight

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,5 @@ _Describe your changes here_
 
 ## Contribution Checklist
 * [ ] Unit tests!
-* [ ] Updated [CHANGELOG.md]
-* [ ] My name is in [CONTRIBUTORS.md]
+* [ ] Updated [CHANGELOG.md](CHANGELOG.md)
+* [ ] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## In Development
+### Added
+- Number Insight now supports the `cnam` parameter for Standard and Advanced requests.
+
 ## [2.0.1] - 2017-03-18
 ### Changed
 - Made servlet-api an optional dependency so it isn't bundled in war files. (This

--- a/src/main/java/com/nexmo/client/insight/CallerType.java
+++ b/src/main/java/com/nexmo/client/insight/CallerType.java
@@ -21,41 +21,15 @@
  */
 package com.nexmo.client.insight;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
-public class BaseInsightRequest {
-    protected static final String DEFAULT_COUNTRY = null;
+public enum CallerType {
+    BUSINESS,
+    CONSUMER,
+    UNKNOWN;
 
-    protected final String number;
-    protected final String country;
-
-    public BaseInsightRequest(String number, String country) {
-        this.number = number;
-        this.country = country;
-    }
-
-    public String getNumber() {
-        return number;
-    }
-
-    public String getCountry() {
-        return country;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        } else if (obj == this) {
-            return true;
-        } else if (obj.getClass() != this.getClass()) {
-            return false;
-        } else {
-            BaseInsightRequest other = (BaseInsightRequest) obj;
-            return new EqualsBuilder()
-                    .append(this.getNumber(), other.getNumber())
-                    .append(this.getCountry(), other.getCountry())
-                    .isEquals();
-        }
+    @JsonCreator
+    public static CallerType fromString(String name) {
+        return CallerType.valueOf(name.toUpperCase());
     }
 }

--- a/src/main/java/com/nexmo/client/insight/InsightClient.java
+++ b/src/main/java/com/nexmo/client/insight/InsightClient.java
@@ -69,18 +69,32 @@ public class InsightClient {
         return this.standard.execute(new StandardInsightRequest(number));
     }
 
-    public StandardInsightResponse getStandardNumberInsight(String number, String country) throws IOException,
-                                                                                                  NexmoClientException {
+    public StandardInsightResponse getStandardNumberInsight(
+            String number, String country) throws IOException, NexmoClientException {
         return this.standard.execute(new StandardInsightRequest(number, country));
+    }
+
+    public StandardInsightResponse getStandardNumberInsight(
+            String number, String country, boolean cnam) throws IOException, NexmoClientException {
+        return this.standard.execute(new StandardInsightRequest(number, country, cnam));
     }
 
     public AdvancedInsightResponse getAdvancedNumberInsight(String number) throws IOException, NexmoClientException {
         return this.advanced.execute(new AdvancedInsightRequest(number));
     }
 
-    public AdvancedInsightResponse getAdvancedNumberInsight(String number, String country, String ipAddress) throws
-                                                                                                             IOException,
-                                                                                                             NexmoClientException {
+    public AdvancedInsightResponse getAdvancedNumberInsight(
+            String number, String country) throws IOException, NexmoClientException {
+        return this.advanced.execute(new AdvancedInsightRequest(number, country));
+    }
+
+    public AdvancedInsightResponse getAdvancedNumberInsight(
+            String number, String country, String ipAddress) throws IOException, NexmoClientException {
         return this.advanced.execute(new AdvancedInsightRequest(number, country, ipAddress));
+    }
+
+    public AdvancedInsightResponse getAdvancedNumberInsight(
+            String number, String country, String ipAddress, boolean cnam) throws IOException, NexmoClientException {
+        return this.advanced.execute(new AdvancedInsightRequest(number, country, ipAddress, cnam));
     }
 }

--- a/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightEndpoint.java
+++ b/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightEndpoint.java
@@ -59,6 +59,9 @@ public class AdvancedInsightEndpoint extends AbstractMethod<AdvancedInsightReque
         if (request.getIpAddress() != null) {
             requestBuilder.addParameter("ip", request.getIpAddress());
         }
+        if (request.getCnam() != null) {
+            requestBuilder.addParameter("cnam", request.getCnam().toString());
+        }
         return requestBuilder;
     }
 

--- a/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightRequest.java
+++ b/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightRequest.java
@@ -25,19 +25,32 @@ import com.nexmo.client.insight.BaseInsightRequest;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
 public class AdvancedInsightRequest extends BaseInsightRequest {
-    private String ipAddress;
+    private static final Boolean DEFAULT_CNAM = null;
+    private final static String DEFAULT_IP_ADDRESS = null;
+    private final String ipAddress;
+    private final Boolean cnam;
+
 
     public AdvancedInsightRequest(String number) {
-        super(number, null);
+        this(number, DEFAULT_COUNTRY);
     }
 
     public AdvancedInsightRequest(String number, String country) {
-        super(number, country);
+        this(number, country, DEFAULT_IP_ADDRESS);
     }
 
     public AdvancedInsightRequest(String number, String country, String ipAddress) {
+        this(number, country, ipAddress, DEFAULT_CNAM);
+    }
+
+    public AdvancedInsightRequest(String number, String country, String ipAddress, Boolean cnam) {
         super(number, country);
+        this.cnam = cnam;
         this.ipAddress = ipAddress;
+    }
+
+    public Boolean getCnam() {
+        return cnam;
     }
 
     public String getIpAddress() {
@@ -56,6 +69,7 @@ public class AdvancedInsightRequest extends BaseInsightRequest {
             AdvancedInsightRequest other = (AdvancedInsightRequest) obj;
             return new EqualsBuilder()
                     .appendSuper(super.equals(other))
+                    .append(this.getCnam(), other.getCnam())
                     .append(this.getIpAddress(), other.getIpAddress())
                     .isEquals();
         }

--- a/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightRequest.java
+++ b/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightRequest.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 
 public class AdvancedInsightRequest extends BaseInsightRequest {
     private static final Boolean DEFAULT_CNAM = null;
-    private final static String DEFAULT_IP_ADDRESS = null;
+    private static final String DEFAULT_IP_ADDRESS = null;
     private final String ipAddress;
     private final Boolean cnam;
 

--- a/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightResponse.java
+++ b/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightResponse.java
@@ -29,7 +29,6 @@ import com.nexmo.client.NexmoUnexpectedException;
 import com.nexmo.client.insight.CallerType;
 import com.nexmo.client.insight.RoamingDetails;
 import com.nexmo.client.insight.standard.StandardInsightResponse;
-import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import java.io.IOException;
 

--- a/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightResponse.java
+++ b/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightResponse.java
@@ -26,8 +26,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexmo.client.NexmoUnexpectedException;
+import com.nexmo.client.insight.CallerType;
 import com.nexmo.client.insight.RoamingDetails;
 import com.nexmo.client.insight.standard.StandardInsightResponse;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import java.io.IOException;
 
@@ -39,6 +41,11 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
     private Integer lookupOutcome;
     private String lookupOutcomeMessage;
     private RoamingDetails roaming;
+    private String callerName;
+    private String firstName;
+    private String lastName;
+    private CallerType callerType;
+
 
     public static AdvancedInsightResponse fromJson(String json) {
         try {
@@ -75,6 +82,26 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
 
     public RoamingDetails getRoaming() {
         return roaming;
+    }
+
+    @JsonProperty("caller_name")
+    public String getCallerName() {
+        return callerName;
+    }
+
+    @JsonProperty("first_name")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("last_name")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("caller_type")
+    public CallerType getCallerType() {
+        return callerType;
     }
 
     public enum PortedStatus {
@@ -115,5 +142,4 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
             return Reachability.valueOf(name.toUpperCase());
         }
     }
-
 }

--- a/src/main/java/com/nexmo/client/insight/basic/BasicInsightRequest.java
+++ b/src/main/java/com/nexmo/client/insight/basic/BasicInsightRequest.java
@@ -24,13 +24,11 @@ package com.nexmo.client.insight.basic;
 import com.nexmo.client.insight.BaseInsightRequest;
 
 public class BasicInsightRequest extends BaseInsightRequest {
-
     public BasicInsightRequest(String number) {
-        super(number, null);
+        this(number, DEFAULT_COUNTRY);
     }
 
     public BasicInsightRequest(String number, String country) {
         super(number, country);
     }
-
 }

--- a/src/main/java/com/nexmo/client/insight/standard/StandardInsightEndpoint.java
+++ b/src/main/java/com/nexmo/client/insight/standard/StandardInsightEndpoint.java
@@ -57,6 +57,9 @@ public class StandardInsightEndpoint extends AbstractMethod<StandardInsightReque
         if (request.getCountry() != null) {
             requestBuilder.addParameter("country", request.getCountry());
         }
+        if (request.getCnam() != null) {
+            requestBuilder.addParameter("cnam", request.getCnam().toString());
+        }
         return requestBuilder;
     }
 

--- a/src/main/java/com/nexmo/client/insight/standard/StandardInsightRequest.java
+++ b/src/main/java/com/nexmo/client/insight/standard/StandardInsightRequest.java
@@ -22,14 +22,44 @@
 package com.nexmo.client.insight.standard;
 
 import com.nexmo.client.insight.BaseInsightRequest;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 public class StandardInsightRequest extends BaseInsightRequest {
+    private static final Boolean DEFAULT_CNAM = null;
+
+    private final Boolean cnam;
+
     public StandardInsightRequest(String number) {
-        super(number, null);
+        this(number, DEFAULT_COUNTRY);
     }
 
     public StandardInsightRequest(String number, String country) {
-        super(number, country);
+        this(number, country, DEFAULT_CNAM);
     }
 
+    public StandardInsightRequest(String number, String country, Boolean cnam) {
+        super(number, country);
+        this.cnam = cnam;
+    }
+
+    public Boolean getCnam() {
+        return cnam;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (obj == this) {
+            return true;
+        } else if (obj.getClass() != this.getClass()) {
+            return false;
+        } else {
+            StandardInsightRequest other = (StandardInsightRequest) obj;
+            return new EqualsBuilder()
+                    .appendSuper(super.equals(obj))
+                    .append(this.getCnam(), other.getCnam())
+                    .isEquals();
+        }
+    }
 }

--- a/src/main/java/com/nexmo/client/insight/standard/StandardInsightResponse.java
+++ b/src/main/java/com/nexmo/client/insight/standard/StandardInsightResponse.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexmo.client.NexmoUnexpectedException;
 import com.nexmo.client.insight.CallerType;
 import com.nexmo.client.insight.CarrierDetails;
-import com.nexmo.client.insight.advanced.AdvancedInsightResponse;
 import com.nexmo.client.insight.basic.BasicInsightResponse;
 
 import java.io.IOException;

--- a/src/main/java/com/nexmo/client/insight/standard/StandardInsightResponse.java
+++ b/src/main/java/com/nexmo/client/insight/standard/StandardInsightResponse.java
@@ -25,7 +25,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexmo.client.NexmoUnexpectedException;
+import com.nexmo.client.insight.CallerType;
 import com.nexmo.client.insight.CarrierDetails;
+import com.nexmo.client.insight.advanced.AdvancedInsightResponse;
 import com.nexmo.client.insight.basic.BasicInsightResponse;
 
 import java.io.IOException;
@@ -36,6 +38,10 @@ public class StandardInsightResponse extends BasicInsightResponse {
     private String remainingBalance;
     private CarrierDetails originalCarrier;
     private CarrierDetails currentCarrier;
+    private String callerName;
+    private String firstName;
+    private String lastName;
+    private CallerType callerType;
 
     public static StandardInsightResponse fromJson(String json) {
         try {
@@ -64,5 +70,25 @@ public class StandardInsightResponse extends BasicInsightResponse {
     @JsonProperty("current_carrier")
     public CarrierDetails getCurrentCarrier() {
         return currentCarrier;
+    }
+
+    @JsonProperty("caller_name")
+    public String getCallerName() {
+        return callerName;
+    }
+
+    @JsonProperty("first_name")
+    public String getFirstName() {
+        return firstName;
+    }
+
+    @JsonProperty("last_name")
+    public String getLastName() {
+        return lastName;
+    }
+
+    @JsonProperty("caller_type")
+    public CallerType getCallerType() {
+        return callerType;
     }
 }

--- a/src/test/java/com/nexmo/client/insight/InsightClientTest.java
+++ b/src/test/java/com/nexmo/client/insight/InsightClientTest.java
@@ -47,7 +47,6 @@ public class InsightClientTest {
     public void testGetBasicNumberInsight() throws Exception {
         client.getBasicNumberInsight("12345");
         verify(client.basic).execute(eq(new BasicInsightRequest("12345")));
-
     }
 
     @Test

--- a/src/test/java/com/nexmo/client/insight/InsightClientTest.java
+++ b/src/test/java/com/nexmo/client/insight/InsightClientTest.java
@@ -69,6 +69,11 @@ public class InsightClientTest {
         verify(client.standard).execute(eq(new StandardInsightRequest("12345", "GB")));
     }
 
+    @Test
+    public void testGetStandardNumberInsight2() throws Exception {
+        client.getStandardNumberInsight("12345", "GB", true);
+        verify(client.standard).execute(eq(new StandardInsightRequest("12345", "GB", true)));
+    }
 
     @Test
     public void testGetAdvancedNumberInsight() throws Exception {
@@ -79,8 +84,20 @@ public class InsightClientTest {
 
     @Test
     public void testGetAdvancedNumberInsight1() throws Exception {
+        client.getAdvancedNumberInsight("12345", "GB");
+        verify(client.advanced).execute(eq(new AdvancedInsightRequest("12345", "GB")));
+    }
+
+    @Test
+    public void testGetAdvancedNumberInsight2() throws Exception {
         client.getAdvancedNumberInsight("12345", "GB", "123.123.123.123");
         verify(client.advanced).execute(eq(new AdvancedInsightRequest("12345", "GB", "123.123.123.123")));
+    }
+
+    @Test
+    public void testGetAdvancedNumberInsight3() throws Exception {
+        client.getAdvancedNumberInsight("12345", "GB", "123.123.123.123", true);
+        verify(client.advanced).execute(eq(new AdvancedInsightRequest("12345", "GB", "123.123.123.123", true)));
     }
 
 }

--- a/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightEndpointTest.java
+++ b/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightEndpointTest.java
@@ -68,6 +68,20 @@ public class AdvancedInsightEndpointTest {
         assertEquals(params.get("number"), "1234");
         assertEquals(params.get("country"), "GB");
         assertEquals(params.get("ip"), "123.123.123.123");
+        assertNull(params.get("cnam"));
+    }
+
+    @Test
+    public void testMakeRequestWithCnam() throws Exception {
+        RequestBuilder builder = this.endpoint.makeRequest(new AdvancedInsightRequest("1234", "GB",
+                "123.123.123.123", true));
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/ni/advanced/json", builder.build().getURI().toString());
+        Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
+        assertEquals(params.get("number"), "1234");
+        assertEquals(params.get("country"), "GB");
+        assertEquals(params.get("ip"), "123.123.123.123");
+        assertEquals(params.get("cnam"), "true");
     }
 
     @Test

--- a/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightRequestTest.java
+++ b/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightRequestTest.java
@@ -55,8 +55,19 @@ public class AdvancedInsightRequestTest {
         AdvancedInsightRequest bir = new AdvancedInsightRequest("1234");
         assertTrue(bir.equals(bir));
         assertTrue(new AdvancedInsightRequest("1234").equals(new AdvancedInsightRequest("1234")));
-        assertFalse(new AdvancedInsightRequest("1234").equals(new AdvancedInsightRequest("1235")));
+        assertFalse(new AdvancedInsightRequest("1234").equals(new AdvancedInsightRequest("7890")));
         assertFalse(new AdvancedInsightRequest("1234", "GB", "123.123.123.123").equals(
                 new AdvancedInsightRequest("1234", "GB", "123.123.123.124")));
+
+        {
+            AdvancedInsightRequest req1 = new AdvancedInsightRequest(
+                    "1234", "GB", "123.123.123.123", true);
+            AdvancedInsightRequest req2 = new AdvancedInsightRequest(
+                    "1234", "GB", "123.123.123.123", false);
+            assertFalse(
+                    "Differing cnam values should result in non-equals",
+                    req1.equals(req2)
+            );
+        }
     }
 }

--- a/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightResponseTest.java
+++ b/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightResponseTest.java
@@ -22,6 +22,7 @@
 package com.nexmo.client.insight.advanced;
 
 import com.nexmo.client.NexmoUnexpectedException;
+import com.nexmo.client.insight.CallerType;
 import com.nexmo.client.insight.CarrierDetails;
 import com.nexmo.client.insight.RoamingDetails;
 import org.junit.Test;
@@ -61,7 +62,11 @@ public class AdvancedInsightResponseTest {
                 "    \"valid_number\": \"valid\",\n" +
                 "    \"reachable\": \"unknown\",\n" +
                 "    \"ported\": \"assumed_not_ported\",\n" +
-                "    \"roaming\": {\"status\": \"not_roaming\"}\n" +
+                "    \"roaming\": {\"status\": \"not_roaming\"},\n" +
+                "    \"first_name\": \"Bob\",\n" +
+                "    \"last_name\": \"Atkey\",\n" +
+                "    \"caller_name\": \"Monads, Incorporated\",\n" +
+                "    \"caller_type\": \"unknown\"\n" +
                 "}");
 
         assertEquals(0, response.getStatus());
@@ -96,6 +101,10 @@ public class AdvancedInsightResponseTest {
         assertEquals(new Integer(1), response.getLookupOutcome());
         assertEquals("Partial success - some fields populated", response.getLookupOutcomeMessage());
 
+        assertEquals("Bob", response.getFirstName());
+        assertEquals("Atkey", response.getLastName());
+        assertEquals("Monads, Incorporated", response.getCallerName());
+        assertEquals(CallerType.UNKNOWN, response.getCallerType());
     }
 
     @Test

--- a/src/test/java/com/nexmo/client/insight/standard/StandardInsightEndpointTest.java
+++ b/src/test/java/com/nexmo/client/insight/standard/StandardInsightEndpointTest.java
@@ -68,6 +68,17 @@ public class StandardInsightEndpointTest {
     }
 
     @Test
+    public void testMakeRequestWithCnam() throws Exception {
+        RequestBuilder builder = this.endpoint.makeRequest(new StandardInsightRequest("1234", "GB", true));
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/ni/standard/json", builder.build().getURI().toString());
+        Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
+        assertEquals(params.get("number"), "1234");
+        assertEquals(params.get("country"), "GB");
+        assertEquals(params.get("cnam"), "true");
+    }
+
+    @Test
     public void testParseResponse() throws Exception {
         HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
                 "    \"status\": 0,\n" +

--- a/src/test/java/com/nexmo/client/insight/standard/StandardInsightRequestTest.java
+++ b/src/test/java/com/nexmo/client/insight/standard/StandardInsightRequestTest.java
@@ -32,6 +32,7 @@ public class StandardInsightRequestTest {
         StandardInsightRequest request = new StandardInsightRequest("12345");
         assertEquals(request.getNumber(), "12345");
         assertNull(request.getCountry());
+        assertNull(request.getCnam());
     }
 
     @Test
@@ -39,16 +40,52 @@ public class StandardInsightRequestTest {
         StandardInsightRequest request = new StandardInsightRequest("12345", "GB");
         assertEquals(request.getNumber(), "12345");
         assertEquals(request.getCountry(), "GB");
+        assertNull(request.getCnam());
+    }
+
+    @Test
+    public void testConstructor3() throws Exception {
+        StandardInsightRequest request = new StandardInsightRequest("12345", "GB", true);
+        assertEquals(request.getNumber(), "12345");
+        assertEquals(request.getCountry(), "GB");
+        assertTrue(request.getCnam());
     }
 
     @Test
     public void testEquals() throws Exception {
         assertFalse(new StandardInsightRequest("1234").equals(null));
         assertFalse(new StandardInsightRequest("1234").equals(new Object()));
-        StandardInsightRequest bir = new StandardInsightRequest("1234");
-        assertTrue(bir.equals(bir));
-        assertTrue(new StandardInsightRequest("1234").equals(new StandardInsightRequest("1234")));
-        assertFalse(new StandardInsightRequest("1234").equals(new StandardInsightRequest("1235")));
+        StandardInsightRequest sir = new StandardInsightRequest("1234");
+        assertTrue(
+                "An object should be equal to itself",
+                sir.equals(sir));
+        {
+            StandardInsightRequest si1 = new StandardInsightRequest("1234", "GB", true);
+            StandardInsightRequest si2 = new StandardInsightRequest("1234", "GB", true);
+            assertTrue(
+                    "StandardInsightRequests created with the same values should be equal.",
+                    si1.equals(si2));
+        }
+
+        assertFalse(
+                "Different number should result in non-equals",
+                new StandardInsightRequest("1234").equals(new StandardInsightRequest("7891")));
+
+        {
+            StandardInsightRequest si1 = new StandardInsightRequest("1234", "GB");
+            StandardInsightRequest si2 = new StandardInsightRequest("1234", "US");
+            assertFalse(
+                    "Different country values should result in non-equals",
+                    si1.equals(si2));
+        }
+
+        {
+            StandardInsightRequest si1 = new StandardInsightRequest("1234", null, true);
+            StandardInsightRequest si2 = new StandardInsightRequest("1234", null, false);
+            assertFalse(
+                    "Different cnam values should result in non-equals",
+                    si1.equals(si2));
+        }
     }
 
 }

--- a/src/test/java/com/nexmo/client/insight/standard/StandardInsightResponseTest.java
+++ b/src/test/java/com/nexmo/client/insight/standard/StandardInsightResponseTest.java
@@ -22,6 +22,7 @@
 package com.nexmo.client.insight.standard;
 
 import com.nexmo.client.NexmoUnexpectedException;
+import com.nexmo.client.insight.CallerType;
 import com.nexmo.client.insight.CarrierDetails;
 import org.junit.Test;
 
@@ -56,7 +57,11 @@ public class StandardInsightResponseTest {
                         "        \"country\": \"GB\",\n" +
                         "        \"network_type\": \"mobile\"\n" +
                         "    },\n" +
-                        "    \"ported\": \"assumed_not_ported\"\n" +
+                        "    \"ported\": \"assumed_not_ported\",\n" +
+                        "    \"first_name\": \"Bob\",\n" +
+                        "    \"last_name\": \"Atkey\",\n" +
+                        "    \"caller_name\": \"Monads, Incorporated\",\n" +
+                        "    \"caller_type\": \"business\"\n" +
                         "}");
 
         assertEquals(0, response.getStatus());
@@ -83,6 +88,11 @@ public class StandardInsightResponseTest {
 
         assertEquals("18.34408949", response.getRemainingBalance());
         assertEquals("0.00500000", response.getRequestPrice());
+
+        assertEquals("Bob", response.getFirstName());
+        assertEquals("Atkey", response.getLastName());
+        assertEquals("Monads, Incorporated", response.getCallerName());
+        assertEquals(CallerType.BUSINESS, response.getCallerType());
     }
 
     @Test


### PR DESCRIPTION
Added the new `cnam` parameter for Standard and Advanced Insight requests, along with the necessary additions to the response objects.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md]
* [x] My name is in [CONTRIBUTORS.md]
