### PR TITLE
A fix for SMS requests being made using ISO-8859-1 instead of UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## In Development
+### Fixed
+- All URL-encoded PUT and POST requests are now UTF-8 instead of ISO-8859-1.
+
 ## [2.0.1] - 2017-03-18
 ### Changed
 - Made servlet-api an optional dependency so it isn't bundled in war files. (This

--- a/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
@@ -82,6 +82,11 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
 
             // If we have a URL Encoded form entity, we may need to regenerate it as UTF-8
             // due to a bug (or two!) in RequestBuilder:
+            //
+            // This fix can be removed when HttpClient is upgraded to 4.5, although 4.5 also
+            // has a bug where RequestBuilder.put(uri) and RequestBuilder.post(uri) use the
+            // wrong encoding, whereas RequestBuilder.put().setUri(uri) uses UTF-8.
+            // - MS 2017-04-12
             if (httpRequest instanceof HttpEntityEnclosingRequest) {
                 HttpEntityEnclosingRequest entityRequest =
                         (HttpEntityEnclosingRequest) httpRequest;

--- a/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
@@ -27,8 +27,11 @@ import com.nexmo.client.NexmoUnexpectedException;
 import com.nexmo.client.auth.AuthMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
@@ -36,6 +39,7 @@ import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -73,7 +77,21 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
     // TODO: Consider wrapping IOException in a nexmo-specific transport exception.
     public ResultT execute(RequestT request) throws IOException, NexmoClientException {
         try {
-            HttpUriRequest httpRequest = applyAuth(makeRequest(request)).build();
+            RequestBuilder requestBuilder = applyAuth(makeRequest(request));
+            HttpUriRequest httpRequest = requestBuilder.build();
+
+            // If we have a URL Encoded form entity, we may need to regenerate it as UTF-8
+            // due to a bug (or two!) in RequestBuilder:
+            if (httpRequest instanceof HttpEntityEnclosingRequest) {
+                HttpEntityEnclosingRequest entityRequest =
+                        (HttpEntityEnclosingRequest) httpRequest;
+                HttpEntity entity = entityRequest.getEntity();
+                if (entity != null && entity instanceof UrlEncodedFormEntity) {
+                    entityRequest.setEntity(new UrlEncodedFormEntity(
+                            requestBuilder.getParameters(),
+                            Charset.forName("UTF-8")));
+                }
+            }
             LOG.debug("Request: " + httpRequest);
             if (LOG.isDebugEnabled() && httpRequest instanceof HttpEntityEnclosingRequestBase) {
                 HttpEntityEnclosingRequestBase enclosingRequest = (HttpEntityEnclosingRequestBase) httpRequest;

--- a/src/test/java/com/nexmo/client/sms/SendMessageEndpointTest.java
+++ b/src/test/java/com/nexmo/client/sms/SendMessageEndpointTest.java
@@ -369,9 +369,6 @@ public class SendMessageEndpointTest {
 
         Message message = new TextMessage("TestSender", "not-a-number", "Test", true);
         endpoint = new SendMessageEndpoint(wrapper);
-                /*assertEquals(
-                "application/x-www-form-urlencoded; charset=UTF-8",
-                request.getEntity().getContentType().getValue());*/
         endpoint.execute(message);
 
         verify(client).execute(argument.capture());

--- a/src/test/java/com/nexmo/client/voice/endpoints/CallTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/CallTest.java
@@ -23,8 +23,8 @@ package com.nexmo.client.voice.endpoints;
 
 import com.nexmo.client.NexmoUnexpectedException;
 import com.nexmo.client.voice.Call;
-import com.nexmo.client.voice.PhoneEndpoint;
 import com.nexmo.client.voice.MachineDetection;
+import com.nexmo.client.voice.PhoneEndpoint;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
A bug in HttpClient <=4.4 means that charset is ignored for the entities added to PUT and POST requests.

This fix intercepts the `HttpRequest` created by `RequestBuilder.build()`, and manually sets the Entity with a UTF-8 encoded version, if a `UrlEncodedFormEntity` is found.

An alternative approach would have been to upgrade HttpClient to 4.5+ and change all the calls to `RequestBuilder.post(url)` (and other methods) to `RequestBuilder.post().setUri(uri)` everywhere in the code (because of a different bug that still exists in 4.5+).

This PR addresses #60 

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md]
* [x] My name is in [CONTRIBUTORS.md]
