### PR TITLE
Send Event Url as a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## In Development
 ### Added
 - Number Insight now supports the `cnam` parameter for Standard and Advanced requests.
-- The event url is properly set on a call `Call`
+- The event url is properly set on a `Call`
 
 ## [2.0.1] - 2017-03-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## In Development
 ### Added
 - Number Insight now supports the `cnam` parameter for Standard and Advanced requests.
+- The event url is properly set on a call `Call`
 
 ## [2.0.1] - 2017-03-18
 ### Changed

--- a/src/main/java/com/nexmo/client/voice/Call.java
+++ b/src/main/java/com/nexmo/client/voice/Call.java
@@ -101,8 +101,11 @@ public class Call {
     }
 
     @JsonProperty("event_url")
-    public String getEventUrl() {
-        return eventUrl;
+    public String[] getEventUrl() {
+        if (eventUrl == null) {
+            return null;
+        }
+        return new String[]{eventUrl};
     }
 
     public void setEventUrl(String eventUrl) {

--- a/src/test/java/com/nexmo/client/voice/endpoints/CallTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/CallTest.java
@@ -70,7 +70,7 @@ public class CallTest {
         assertEquals("BREW", call.getAnswerMethod());
         assertEquals("https://answer.example.com/", call.getAnswerUrl()[0]);
         assertEquals("RUN", call.getEventMethod());
-        assertEquals("https://events.example.com/", call.getEventUrl());
+        assertEquals("https://events.example.com/", call.getEventUrl()[0]);
         assertEquals(from, call.getFrom());
         assertEquals(101, call.getLengthTimer().intValue());
         assertEquals(MachineDetection.CONTINUE, call.getMachineDetection());


### PR DESCRIPTION
Fixes #63

Treat `eventUrl` as an array, not as a String

## Contribution Checklist
* [X] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [X] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
