### PR TITLE
Add setter for statusReportRequired. Resolves #71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## In Development
+### Added
+- Add missing setter for the Message.statusReportRequired property.
+
 ## [2.0.2] - 2017-05-04
 ### Fixed
 - All URL-encoded PUT and POST requests are now UTF-8 instead of ISO-8859-1.

--- a/src/main/java/com/nexmo/client/sms/messages/Message.java
+++ b/src/main/java/com/nexmo/client/sms/messages/Message.java
@@ -158,12 +158,23 @@ public abstract class Message {
     }
 
     /**
-     * @return boolean if set to true, then a delivery notification will be requested for this message delivery attempt.
-     * upon receiving notification of delivery or failure from the network, the nexmo platform will submit a notification to the url configured in your
-     * nexmo rest account that represents the outcome of this message.
+     * Get the value of the 'status-report-req' parameter.
      */
     public boolean getStatusReportRequired() {
         return this.statusReportRequired;
+    }
+
+    /**
+     * Set the value of the 'status-report-req' parameter.
+     *
+     * If set to 'true', Nexmo will call 'callbackUrl' with status updates about the delivery of this message. If this
+     * value is set to 'true', then 'callbackUrl' should also be set to a URL that is configured to receive these
+     * status updates.
+     *
+     * @param statusReportRequired 'true' if status reports are desired, 'false' otherwise.
+     */
+    public void setStatusReportRequired(boolean statusReportRequired) {
+        this.statusReportRequired = statusReportRequired;
     }
 
     public void addParams(RequestBuilder request) {

--- a/src/test/java/com/nexmo/client/sms/SendMessageEndpointTest.java
+++ b/src/test/java/com/nexmo/client/sms/SendMessageEndpointTest.java
@@ -70,6 +70,19 @@ public class SendMessageEndpointTest {
     }
 
     @Test
+    public void testStatusReportRequiredSetter() throws Exception {
+        Message message = new TextMessage("TestSender", "not-a-number", "Test");
+        message.setStatusReportRequired(true);
+        List<NameValuePair> params = endpoint.makeRequest(message).getParameters();
+
+        assertContainsParam(params, "from", "TestSender");
+        assertContainsParam(params, "to", "not-a-number");
+        assertContainsParam(params, "type", "text");
+        assertContainsParam(params, "status-report-req", "1");
+        assertContainsParam(params, "text", "Test");
+    }
+
+    @Test
     public void testConstructParamsUnicode() throws Exception {
         Message message = new TextMessage("TestSender", "not-a-number", "Test", true);
 


### PR DESCRIPTION
There was a missing setter for the statusReportRequired property, reported in #71. This PR adds it in.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
