### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 ---
 sudo: false
+dist: precise
 language: java
 
 jdk:
   - oraclejdk8
   - oraclejdk7
-  #- openjdk6
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Travis has changed its default image to Trusty, which no longer has a working version of Oracle JDK 7.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
