### PR TITLE
Modify call - support 204

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 3.1.0
+current_version = 3.2.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
 ## [Development]
+
+Entries go here.
+
+## [3.2.0] - 2017-11-30
 
 ### Modified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Development]
 
-Entries go here.
+### Modified
+
+- Modify call now works with the API again, returning `null` (because the API now returns 204 No Content)
 
 ## [3.2.0] - 2017-11-30
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nexmo Client Library for Java
 
-<!-- [![Maven Release](https://maven-badges.herokuapp.com/maven-central/com.nexmo/client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.nexmo/client) -->
+[![Maven Release](https://maven-badges.herokuapp.com/maven-central/com.nexmo/client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.nexmo/client)
 [![Build Status](https://travis-ci.org/Nexmo/nexmo-java.svg?branch=version-2)](https://travis-ci.org/Nexmo/nexmo-java)
 [![codecov](https://codecov.io/gh/Nexmo/nexmo-java/branch/version-2/graph/badge.svg)](https://codecov.io/gh/Nexmo/nexmo-java)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/9888a9f2ec0d4599a11762e5d946da17)](https://www.codacy.com/app/mark-smith/nexmo-java?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Nexmo/nexmo-java&amp;utm_campaign=Badge_Grade)
@@ -11,9 +11,8 @@ need a Nexmo account. Sign up [for free at nexmo.com][signup].
 
  * [Installation](#installation)
  * [Usage](#usage)
- * [Examples](#examples)
- * [API Coverage](#api-coverage)
- * [Contribute](#contribute)
+ * [Tips And Tricks](#tips-and-tricks)
+ * [Contribute!](#contribute)
 
 ## Installation
 
@@ -29,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.nexmo:client:3.1.0'
+    compile 'com.nexmo:client:3.2.0'
 }
 ```
 
@@ -41,7 +40,7 @@ Add the following to the correct place in your project's POM file:
 <dependency>
       <groupId>com.nexmo</groupId>
       <artifactId>client</artifactId>
-      <version>3.1.0</version>
+      <version>3.2.0</version>
 </dependency>
 ```
 
@@ -70,10 +69,11 @@ to your project's classpath.
 
 ## Usage
 
-Check the [Javadoc](http://nexmo.github.io/nexmo-java/) for full
-reference documentation. There are also many useful code samples in the [nexmo-community/nexmo-java-quickstart](https://github.com/nexmo-community/nexmo-java-quickstart) repository.
+* For help understanding our APIs, check out our awesome [developer portal](https://developer.nexmo.com/)
+* Check the [Javadoc](http://nexmo.github.io/nexmo-java/) for full reference documentation.
+* There are also **many useful code samples** in our [nexmo-community/nexmo-java-quickstart](https://github.com/nexmo-community/nexmo-java-quickstart) repository.
 
-## Send an SMS
+### Send an SMS
 
 Send an SMS with the Nexmo SMS API:
 
@@ -91,7 +91,7 @@ for (SmsSubmissionResult response : responses) {
 }
 ```
 
-## Make Phone Calls
+### Make Phone Calls
 
 The following code initiates an outbound call which then reads the user [a message](https://nexmo-community.github.io/ncco-examples/first_call_talk.json):
 
@@ -159,7 +159,19 @@ TalkResponse stopTalkResponse = client.getVoiceClient().stopTalk(event.getUuid()
 System.out.println("Alright. " + stopTalkResponse.getMessage());
 ```
 
-## Send a 2FA Code
+### Generating NCCO Responses
+
+Our library contains a `com.nexmo.client.voice.ncco` package, providing JSON-serializable objects for your NCCO webhook endpoints. You can use it like this:
+
+```java
+TalkNcco message = new TalkNcco("Thank you for calling!");
+Ncco[] nccos = new Ncco[]{message};
+
+res.type("application/json");
+return nccoMapper.writer().writeValueAsString(nccos);
+```
+
+### Send a 2FA Code
 
 Send a 2FA code to a phone number with:
 
@@ -169,7 +181,7 @@ NexmoClient client = new NexmoClient(auth);
 VerifyResult ongoingVerify = client.getVerifyClient().verify(TO_NUMBER, "NEXMO");
 ```
 
-## Check the 2FA Code
+### Check the 2FA Code
 
 When the user enters the code they received, you can check it like this:
 
@@ -177,60 +189,17 @@ When the user enters the code they received, you can check it like this:
 client.getVerifyClient().check(ongoingVerify.getRequestId(), CODE)
 ```
 
-## Custom HTTP Configuration
+### Custom HTTP Configuration
 
 If you need to configure the Apache HttpClient used for making requests, you can
 call `NexmoClient.setHttpClient()` to supply your custom configured object. This
 can be useful, for example, if you must use an HTTP proxy to make requests.
 
+## Tips And Tricks
 
-## API Coverage
-
-* Account
-    * [x] Balance
-    * [ ] Pricing
-    * [ ] Settings
-    * [ ] Top Up
-    * [ ] Numbers
-        * [ ] Search
-        * [ ] Buy
-        * [ ] Cancel
-        * [ ] Update
-* Number Insight
-    * [x] Basic
-    * [x] Standard
-    * [x] Advanced
-    * [ ] Webhook Notification
-* Verify
-    * [x] Verify
-    * [x] Check
-    * [x] Search
-    * [ ] Control
-* Messaging
-    * [x] Send
-    * [x] Delivery Receipt (Callback can only be set in the Dashboard)
-    * [ ] Inbound Messages
-    * [ ] Search
-        * [ ] Message
-        * [ ] Messages
-        * [ ] Rejections
-    * [ ] US Short Codes
-        * [ ] Two-Factor Authentication
-        * [ ] Event Based Alerts
-            * [ ] Sending Alerts
-            * [ ] Campaign Subscription Management
-* Voice
-    * [x] Create call
-    * [x] List calls
-    * [x] Get call info
-    * [x] Modify existing call
-    * [x] Stream audio to an existing call
-    * [x] Stop streaming audio to an existing call
-    * [x] Send speech to an existing call
-    * [x] Stop speech in an existing call
-    * [x] Send DTMF to an existing call
-    * [ ] eventUrl webhook support
-    * [x] answerUrl webhook support
+### Phone Calls And WebSockets
+Our [Voice API](https://developer.nexmo.com/voice/voice-api/overview) can connect a voice call to a websocket! An example using `javax.websocket` for accepting websocket connections can be found on the [Oracle website](http://www.oracle.com/webfolder/technetwork/tutorials/obe/java/HomeWebsocket/WebsocketHome.html#section4).
+[Another  example](http://sparkjava.com/documentation#embedded-web-server) using the Spark framework
 
 
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'eclipse'
 
 group = "com.nexmo"
 archivesBaseName = "client"
-version = "3.1.0"
+version = "3.2.0"
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
 

--- a/src/main/java/com/nexmo/client/HttpWrapper.java
+++ b/src/main/java/com/nexmo/client/HttpWrapper.java
@@ -85,7 +85,7 @@ public class HttpWrapper {
 
         return HttpClientBuilder.create()
                 .setConnectionManager(connectionManager)
-                .setUserAgent("nexmo-java/3.1.0")
+                .setUserAgent("nexmo-java/3.2.0")
                 .setDefaultRequestConfig(requestConfig)
                 .build();
     }

--- a/src/main/java/com/nexmo/client/voice/endpoints/ModifyCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/ModifyCallMethod.java
@@ -66,7 +66,11 @@ public class ModifyCallMethod extends AbstractMethod<CallModifier, ModifyCallRes
     @Override
     public ModifyCallResponse parseResponse(HttpResponse response) throws IOException {
         String json = new BasicResponseHandler().handleResponse(response);
-        return ModifyCallResponse.fromJson(json);
+        if (response.getStatusLine().getStatusCode() == 200) {
+            return ModifyCallResponse.fromJson(json);
+        } else {
+            return null;
+        }
     }
 
     public void setUri(String uri) {

--- a/src/test/java/com/nexmo/client/voice/endpoints/ModifyCallMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ModifyCallMethodTest.java
@@ -43,6 +43,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ModifyCallMethodTest {
     private static final Log LOG = LogFactory.getLog(ModifyCallMethodTest.class);
@@ -149,6 +150,19 @@ public class ModifyCallMethodTest {
 
         ModifyCallResponse response = methodUnderTest.parseResponse(stubResponse);
         assertEquals("Received", response.getMessage());
+    }
+
+    @Test
+    public void parseNullResponse() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper();
+        ModifyCallMethod methodUnderTest = new ModifyCallMethod(wrapper);
+
+        HttpResponse stubResponse = new BasicHttpResponse(
+                new BasicStatusLine(new ProtocolVersion("1.1", 1, 1), 204, "OK")
+        );
+
+        ModifyCallResponse response = methodUnderTest.parseResponse(stubResponse);
+        assertNull(response);
     }
 
     @Test


### PR DESCRIPTION
The API currently returns 204 responses, resulting in a NullPointerException. This PR fixes that, and results in `null` being returned from the relevant calls.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
