### PR TITLE
StreamNcco serialization fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Modify call now works with the API again, returning `null` (because the API now returns 204 No Content)
 - VerifyRequest now supports all supported parameters.
+- `StreamNcco` serializes/deserializes `streamUrl` field correctly as per documentation
 
 ## [3.2.0] - 2017-11-30
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@ documentation, or tests are eligible to be added to this list.
 - Chris Guzman ([@ChrisGuzman](https://github.com/ChrisGuzman))
 - Tim Lytle ([@tjlitle](https://github.com/tjlitle))
 - [@thepeachbeetle](https://github.com/thepeachbeetle)
+- Ruslan Zaharov ([@ruXlab](https://github.com/ruXlab))

--- a/src/main/java/com/nexmo/client/voice/ncco/StreamNcco.java
+++ b/src/main/java/com/nexmo/client/voice/ncco/StreamNcco.java
@@ -41,12 +41,12 @@ public class StreamNcco implements Ncco {
     }
 
     @JsonSetter("streamUrl")
-    void setStreamUrlArray(String[] streamUrl) {
+    private void setStreamUrlArray(String[] streamUrl) {
         this.streamUrl = streamUrl;
     }
 
     @JsonGetter("streamUrl")
-    String[] getStreamUrlArray() {
+    private String[] getStreamUrlArray() {
         return streamUrl;
     }
 

--- a/src/main/java/com/nexmo/client/voice/ncco/StreamNcco.java
+++ b/src/main/java/com/nexmo/client/voice/ncco/StreamNcco.java
@@ -21,30 +21,44 @@
  */
 package com.nexmo.client.voice.ncco;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamNcco implements Ncco {
     private static final String ACTION = "stream";
 
-    private String streamUrl;
+    private String[] streamUrl = new String[1];
     private Float level = null;
     private Boolean bargeIn = null;
     private Integer loop = null;
 
-    public StreamNcco(@JsonProperty("streamUrl") String streamUrl) {
+    public StreamNcco() {
+    }
+
+    public StreamNcco(String streamUrl) {
+        setStreamUrl(streamUrl);
+    }
+
+    @JsonSetter("streamUrl")
+    void setStreamUrlArray(String[] streamUrl) {
         this.streamUrl = streamUrl;
     }
 
-    public String getStreamUrl() {
+    @JsonGetter("streamUrl")
+    String[] getStreamUrlArray() {
         return streamUrl;
     }
 
+
+    @JsonIgnore
+    public String getStreamUrl() {
+        return streamUrl[0];
+    }
+
+    @JsonIgnore
     public void setStreamUrl(String streamUrl) {
-        this.streamUrl = streamUrl;
+        this.streamUrl = new String[] { streamUrl };
     }
 
     public Float getLevel() {

--- a/src/test/java/com/nexmo/client/voice/ncco/StreamNccoTest.java
+++ b/src/test/java/com/nexmo/client/voice/ncco/StreamNccoTest.java
@@ -30,7 +30,7 @@ public class StreamNccoTest {
     @Test
     public void testToJson() throws Exception {
         assertEquals(
-                "{\"streamUrl\":\"https://api.example.com/stream\",\"action\":\"stream\"}",
+                "{\"action\":\"stream\",\"streamUrl\":[\"https://api.example.com/stream\"]}",
                 new StreamNcco("https://api.example.com/stream").toJson());
     }
 


### PR DESCRIPTION
As per [documentation](https://developer.nexmo.com/api/voice/ncco#stream) `streamUrl` field of NCCO has to be an array with 1 url. At the moment value of `streamUrl` is serialised as a string which causes error.

Sample from unit test doesn't seem to be working in Voice Playground as well:  
![screenshot from 2018-03-04 01-48-16](https://user-images.githubusercontent.com/1110234/36941220-24b7c5c0-1f4e-11e8-917c-d9b8df3fb032.png)

Given solution will not break compatibility with existing code.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
