### PR TITLE
Remove fifteen digit client verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Modify call now works with the API again, returning `null` (because the API now returns 204 No Content)
 - VerifyRequest now supports all supported parameters.
+- Client-side validation for the `from` parameter's length on the `Message` class has been removed.
 
 ### Added
 - Add `level` attribute to the `TalkNcco` object.

--- a/src/main/java/com/nexmo/client/sms/messages/Message.java
+++ b/src/main/java/com/nexmo/client/sms/messages/Message.java
@@ -83,10 +83,6 @@ public abstract class Message {
                       final String from,
                       final String to,
                       final boolean statusReportRequired) {
-        if (from.length() > 15) {
-            throw new IllegalArgumentException("The length of the 'from' argument must be 15 characters or fewer.");
-        }
-
         this.type = type;
         this.from = from;
         this.to = to;


### PR DESCRIPTION
Remove the length restriction on the `from` parameter of the `Message` class.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
