### PR TITLE
Update conversation musicOnHoldUrl to Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Development]
 
+### Fixed
+- Updated `ConversationNcco`'s `musicOnHoldUrl` to serialize into an array for use in the Voice API.
+
 ## [3.4.1] - 2018-05-11
 
 ### Changed

--- a/src/main/java/com/nexmo/client/voice/ncco/ConversationNcco.java
+++ b/src/main/java/com/nexmo/client/voice/ncco/ConversationNcco.java
@@ -55,8 +55,16 @@ public class ConversationNcco implements Ncco {
         return musicOnHoldUrl;
     }
 
-    public void setMusicOnHoldUrl(String musicOnHoldUrl) {
-        this.musicOnHoldUrl = musicOnHoldUrl;
+    @JsonProperty("musicOnHoldUrl")
+    public String[] getMusicOnHoldUrlAsArray() {
+        // TODO: Rework in 4.0.
+        // This property is expected to be serialized as an array, however we want to also insure it remains null
+        // if null.
+        return this.musicOnHoldUrl != null ? new String[]{this.musicOnHoldUrl} : null;
+    }
+
+    public void setMusicOnHoldUrl(String... musicOnHoldUrl) {
+        this.musicOnHoldUrl = musicOnHoldUrl[0];
     }
 
     public Boolean getStartOnEnter() {
@@ -87,12 +95,8 @@ public class ConversationNcco implements Ncco {
         return eventUrl;
     }
 
-    public void setEventUrl(String eventUrl) {
-        setEventUrl(new String[]{eventUrl});
-    }
-
     @JsonProperty("eventUrl")
-    public void setEventUrl(String[] eventUrl) {
+    public void setEventUrl(String... eventUrl) {
         this.eventUrl = eventUrl;
     }
 

--- a/src/test/java/com/nexmo/client/voice/ncco/ConversationNccoTest.java
+++ b/src/test/java/com/nexmo/client/voice/ncco/ConversationNccoTest.java
@@ -30,9 +30,7 @@ public class ConversationNccoTest {
     @Test
     public void testJson() throws Exception {
         ConversationNcco ncco = new ConversationNcco("conversation-name");
-        assertEquals(
-                "{\"name\":\"conversation-name\",\"action\":\"conversation\"}",
-                ncco.toJson());
+        assertEquals("{\"name\":\"conversation-name\",\"action\":\"conversation\"}", ncco.toJson());
     }
 
     @Test
@@ -56,4 +54,67 @@ public class ConversationNccoTest {
         assertEquals(false, ncco2.getStartOnEnter());
     }
 
+    @Test
+    public void testWithOnlyNameParameter() throws Exception {
+        ConversationNcco ncco = new ConversationNcco("Test");
+
+        String expectedJson = "{\"name\":\"Test\",\"action\":\"conversation\"}";
+        assertEquals(expectedJson, ncco.toJson());
+    }
+
+    @Test
+    public void testMusicOnHoldUrl() throws Exception {
+        ConversationNcco ncco = new ConversationNcco("Test");
+        ncco.setMusicOnHoldUrl("https://example.org");
+
+        String expectedJson = "{\"name\":\"Test\",\"musicOnHoldUrl\":[\"https://example.org\"],\"action\":\"conversation\"}";
+        assertEquals(expectedJson, ncco.toJson());
+
+        ncco = new ConversationNcco("Test");
+    }
+
+    @Test
+    public void testStartOnEnter() throws Exception {
+        ConversationNcco ncco = new ConversationNcco("Test");
+        ncco.setStartOnEnter(true);
+
+        String expectedJson = "{\"name\":\"Test\",\"startOnEnter\":true,\"action\":\"conversation\"}";
+        assertEquals(expectedJson, ncco.toJson());
+    }
+
+    @Test
+    public void testEndOnExit() throws Exception {
+        ConversationNcco ncco = new ConversationNcco("Test");
+        ncco.setEndOnExit(true);
+
+        String expectedJson = "{\"name\":\"Test\",\"endOnExit\":true,\"action\":\"conversation\"}";
+        assertEquals(expectedJson, ncco.toJson());
+    }
+
+    @Test
+    public void testRecord() throws Exception {
+        ConversationNcco ncco = new ConversationNcco("Test");
+        ncco.setRecord(true);
+
+        String expectedJson = "{\"name\":\"Test\",\"record\":true,\"action\":\"conversation\"}";
+        assertEquals(expectedJson, ncco.toJson());
+    }
+
+    @Test
+    public void testEventUrl() throws Exception {
+        ConversationNcco ncco = new ConversationNcco("Test");
+        ncco.setEventUrl("https://exmaple.org");
+
+        String expectedJson = "{\"name\":\"Test\",\"action\":\"conversation\",\"eventUrl\":[\"https://exmaple.org\"]}";
+        assertEquals(expectedJson, ncco.toJson());
+    }
+
+    @Test
+    public void testEventMethod() throws Exception {
+        ConversationNcco ncco = new ConversationNcco("Test");
+        ncco.setEventMethod("Test");
+
+        String expectedJson = "{\"name\":\"Test\",\"eventMethod\":\"Test\",\"action\":\"conversation\"}";
+        assertEquals(expectedJson, ncco.toJson());
+    }
 }


### PR DESCRIPTION
Update the `ConversationNcco` so that it correctly serializes the `musicOnHoldUrl` property into an array.  This is a temporary fix to serialization in order to maintain backwards compatibility.

See: #166 for initiative to clean up objects entirely.
Resolves: #164 

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
