### PR TITLE
Add split recording to the RecordNcco object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Development]
 
+### Added
+- Add `split` attribute to the `RecordNcco` object.
+
 ## [3.4.1] - 2018-05-11
 
 ### Changed

--- a/src/main/java/com/nexmo/client/voice/ncco/RecordNcco.java
+++ b/src/main/java/com/nexmo/client/voice/ncco/RecordNcco.java
@@ -37,6 +37,7 @@ public class RecordNcco implements Ncco {
     private Boolean beepStart = null;
     private String[] eventUrl = null;
     private String eventMethod = null;
+    private SplitRecording split = null;
 
     public RecordingFormat getFormat() {
         return format;
@@ -102,6 +103,14 @@ public class RecordNcco implements Ncco {
     @Override
     public String getAction() {
         return ACTION;
+    }
+
+    public SplitRecording getSplit() {
+        return split;
+    }
+
+    public void setSplit(SplitRecording split) {
+        this.split = split;
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/ncco/SplitRecording.java
+++ b/src/main/java/com/nexmo/client/voice/ncco/SplitRecording.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.voice.ncco;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum SplitRecording {
+    CONVERSATION;
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+}

--- a/src/test/java/com/nexmo/client/voice/ncco/RecordNccoTest.java
+++ b/src/test/java/com/nexmo/client/voice/ncco/RecordNccoTest.java
@@ -24,7 +24,8 @@ package com.nexmo.client.voice.ncco;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class RecordNccoTest {
     @Test
@@ -44,7 +45,7 @@ public class RecordNccoTest {
             ncco.setEndOnSilence(3);
             ncco.setFormat(RecordingFormat.MP3);
             ncco.setTimeout(20);
-
+            ncco.setSplit(SplitRecording.CONVERSATION);
             json = ncco.toJson();
         }
 
@@ -52,9 +53,65 @@ public class RecordNccoTest {
         assertArrayEquals(new String[]{"https://api.example.com/event"}, ncco.getEventUrl());
         assertEquals("GET", ncco.getEventMethod());
         assertEquals(true, ncco.getBeepStart());
-        assertEquals('#', (char)ncco.getEndOnKey());
-        assertEquals(3, (int)ncco.getEndOnSilence());
+        assertEquals('#', (char) ncco.getEndOnKey());
+        assertEquals(3, (int) ncco.getEndOnSilence());
         assertEquals(RecordingFormat.MP3, ncco.getFormat());
-        assertEquals(20, (int)ncco.getTimeout());
+        assertEquals(20, (int) ncco.getTimeout());
+        assertEquals(SplitRecording.CONVERSATION, ncco.getSplit());
+    }
+
+    @Test
+    public void testDefault() {
+        RecordNcco ncco = new RecordNcco();
+        assertEquals("{\"action\":\"record\"}", ncco.toJson());
+    }
+
+    @Test
+    public void testEventUrl() {
+        RecordNcco ncco = new RecordNcco();
+        ncco.setEventUrl("https://example.com");
+        assertEquals("{\"action\":\"record\",\"eventUrl\":[\"https://example.com\"]}", ncco.toJson());
+    }
+
+    @Test
+    public void testEventMethod() {
+        RecordNcco ncco = new RecordNcco();
+        ncco.setEventMethod("GET");
+        assertEquals("{\"eventMethod\":\"GET\",\"action\":\"record\"}", ncco.toJson());
+    }
+
+    @Test
+    public void testEndOnKey() {
+        RecordNcco ncco = new RecordNcco();
+        ncco.setEndOnKey('#');
+        assertEquals("{\"endOnKey\":\"#\",\"action\":\"record\"}", ncco.toJson());
+    }
+
+    @Test
+    public void testEndOnSilence() {
+        RecordNcco ncco = new RecordNcco();
+        ncco.setEndOnSilence(3);
+        assertEquals("{\"endOnSilence\":3,\"action\":\"record\"}", ncco.toJson());
+    }
+
+    @Test
+    public void testFormat() {
+        RecordNcco ncco = new RecordNcco();
+        ncco.setFormat(RecordingFormat.WAV);
+        assertEquals("{\"format\":\"wav\",\"action\":\"record\"}", ncco.toJson());
+    }
+
+    @Test
+    public void testTimeout() {
+        RecordNcco ncco = new RecordNcco();
+        ncco.setTimeout(5);
+        assertEquals("{\"timeout\":5,\"action\":\"record\"}", ncco.toJson());
+    }
+
+    @Test
+    public void testSplit() {
+        RecordNcco ncco = new RecordNcco();
+        ncco.setSplit(SplitRecording.CONVERSATION);
+        assertEquals("{\"split\":\"conversation\",\"action\":\"record\"}", ncco.toJson());
     }
 }


### PR DESCRIPTION
Add the option to enable `split` recording to the `RecordNcco` object.  This can be enabled via the following:
```java
RecordNcco ncco = new RecordNcco();
ncco.setSplit(SplitRecording.CONVERSATION);
```

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
