### PR TITLE
Implement Voice and SMS pricing on AccountClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Development]
+### Added
+- Added `getSmsPrice` to `AccountClient` for getting SMS pricing for a country.
+- Added `getVoicePrice` to `AccountClient` for getting voice pricing for a country.
+- Added `getPrefixPrice` to `AccountClient` for getting SMS and voice pricing for a prefix.
 
 ## [3.5.0] - 2018-05-29
 ### Changed

--- a/README.md
+++ b/README.md
@@ -189,6 +189,50 @@ When the user enters the code they received, you can check it like this:
 client.getVerifyClient().check(ongoingVerify.getRequestId(), CODE)
 ```
 
+### Get a List of SMS Prices for a Country
+
+Get a list of SMS prices for a country with:
+
+```java
+AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
+NexmoClient client = new NexmoClient(auth);
+PricingResponse response = client.getAccountClient().getSmsPrice("GB");
+System.out.println(response.getDefaultPrice());
+```
+
+### Get a List of Voice Prices for a Country
+
+Get a list of voice prices for a country with:
+
+```java
+AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
+NexmoClient client = new NexmoClient(auth);
+PricingResponse response = client.getAccountClient().getVoicePrice("US");
+System.out.println(response.getDefaultPrice());
+```
+
+### Get a List of SMS Prices for a Prefix
+
+Get a list of SMS prices for a country with:
+
+```java
+AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
+NexmoClient client = new NexmoClient(auth);
+PricingResponse response = client.getAccountClient().getPrefixPrice(ServiceType.SMS, "1");
+System.out.println(response.getDefaultPrice());
+```
+
+### Get a List of Voice Prices for a Prefix
+
+Get a list of voice prices for a country with:
+
+```java
+AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
+NexmoClient client = new NexmoClient(auth);
+PricingResponse response = client.getAccountClient().getPrefixPrice(ServiceType.VOICE, "1");
+System.out.println(response.getDefaultPrice());
+```
+
 ### Custom HTTP Configuration
 
 If you need to configure the Apache HttpClient used for making requests, you can

--- a/src/main/java/com/nexmo/client/account/AccountClient.java
+++ b/src/main/java/com/nexmo/client/account/AccountClient.java
@@ -21,6 +21,7 @@
  */
 package com.nexmo.client.account;
 
+import com.nexmo.client.AbstractClient;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClient;
 import com.nexmo.client.NexmoClientException;
@@ -31,8 +32,10 @@ import java.io.IOException;
  * A client for talking to the Nexmo Number Insight API. The standard way to obtain an instance of this class is to use
  * {@link NexmoClient#getInsightClient()}.
  */
-public class AccountClient {
+public class AccountClient extends AbstractClient {
     protected BalanceEndpoint balance;
+    protected PricingEndpoint pricing;
+    protected PrefixPricingEndpoint prefixPricing;
 
     /**
      * Constructor.
@@ -40,10 +43,64 @@ public class AccountClient {
      * @param httpWrapper (required) shared HTTP wrapper object used for making REST calls.
      */
     public AccountClient(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+
         this.balance = new BalanceEndpoint(httpWrapper);
+        this.pricing = new PricingEndpoint(httpWrapper);
+        this.prefixPricing = new PrefixPricingEndpoint(httpWrapper);
     }
 
     public BalanceResponse getBalance() throws IOException, NexmoClientException {
         return this.balance.execute();
+    }
+
+    /**
+     * Retrieve the voice pricing for a specified country.
+     *
+     * @param country The two-character country code for which you would like to retrieve pricing.
+     * @return PricingResponse object which contains the results from the API.
+     * @throws IOException          if a network error occurred contacting the Nexmo Account API.
+     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     */
+    public PricingResponse getVoicePrice(String country) throws IOException, NexmoClientException {
+        return getVoicePrice(new PricingRequest(country));
+    }
+
+    private PricingResponse getVoicePrice(PricingRequest pricingRequest) throws IOException, NexmoClientException {
+        return this.pricing.getPrice(ServiceType.VOICE, pricingRequest);
+    }
+
+    /**
+     * Retrieve the SMS pricing for a specified country.
+     *
+     * @param country The two-character country code for which you would like to retrieve pricing.
+     * @return PricingResponse object which contains the results from the API.
+     * @throws IOException          if a network error occurred contacting the Nexmo Account API.
+     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     */
+    public PricingResponse getSmsPrice(String country) throws IOException, NexmoClientException {
+        return getSmsPrice(new PricingRequest(country));
+    }
+
+    private PricingResponse getSmsPrice(PricingRequest pricingRequest) throws IOException, NexmoClientException {
+        return this.pricing.getPrice(ServiceType.SMS, pricingRequest);
+    }
+
+    /**
+     * Retrieve the pricing for a specified prefix.
+     *
+     * @param type   The type of service to retrieve pricing for.
+     * @param prefix The prefix to retrieve the pricing for.
+     * @return PricingResponse object which contains the results from the API.
+     * @throws IOException          if a network error occurred contacting the Nexmo Account API.
+     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     */
+    public PrefixPricingResponse getPrefixPrice(ServiceType type,
+                                                String prefix) throws IOException, NexmoClientException {
+        return getPrefixPrice(new PrefixPricingRequest(type, prefix));
+    }
+
+    private PrefixPricingResponse getPrefixPrice(PrefixPricingRequest prefixPricingRequest) throws IOException, NexmoClientException {
+        return this.prefixPricing.getPrice(prefixPricingRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/account/AccountClient.java
+++ b/src/main/java/com/nexmo/client/account/AccountClient.java
@@ -91,7 +91,7 @@ public class AccountClient extends AbstractClient {
      *
      * @param type   The type of service to retrieve pricing for.
      * @param prefix The prefix to retrieve the pricing for.
-     * @return PricingResponse object which contains the results from the API.
+     * @return PrefixPricingResponse object which contains the results from the API.
      * @throws IOException          if a network error occurred contacting the Nexmo Account API.
      * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
      */

--- a/src/main/java/com/nexmo/client/account/Country.java
+++ b/src/main/java/com/nexmo/client/account/Country.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Country {
+    private String code;
+    private String displayName;
+    private String name;
+
+    @JsonProperty("countryCode")
+    public String getCode() {
+        return code;
+    }
+
+    @JsonProperty("countryDisplayName")
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @JsonProperty("countryName")
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/nexmo/client/account/Network.java
+++ b/src/main/java/com/nexmo/client/account/Network.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Network {
+    private Type type;
+    private BigDecimal price;
+    private String currency;
+    private String mcc;
+    private String mnc;
+    private String code;
+    private String name;
+
+    public Type getType() {
+        return type;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getMcc() {
+        return mcc;
+    }
+
+    public String getMnc() {
+        return mnc;
+    }
+
+    @JsonProperty("networkCode")
+    public String getCode() {
+        return code;
+    }
+
+    @JsonProperty("networkName")
+    public String getName() {
+        return name;
+    }
+
+    enum Type {
+        MOBILE, LANDLINE, PAGER, LANDLINE_TOLLFREE, UNKNOWN;
+
+        private static final Map<String, Type> typesIndex = new HashMap<>();
+
+        static {
+            for (Type type : Type.values()) {
+                typesIndex.put(type.toString(), type);
+            }
+        }
+
+        @Override
+        @JsonValue
+        public String toString() {
+            return name().toLowerCase();
+        }
+
+        @JsonCreator
+        public static Type fromString(String type) {
+            Type foundType = typesIndex.get(type);
+            return (foundType != null) ? foundType : Type.UNKNOWN;
+        }
+    }
+}

--- a/src/main/java/com/nexmo/client/account/PrefixPricingEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/PrefixPricingEndpoint.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoClientException;
+
+import java.io.IOException;
+
+public class PrefixPricingEndpoint {
+    private PrefixPricingMethod prefixPricingMethod;
+
+    PrefixPricingEndpoint(HttpWrapper httpWrapper) {
+        this.prefixPricingMethod = new PrefixPricingMethod(httpWrapper);
+    }
+
+    PrefixPricingResponse getPrice(PrefixPricingRequest prefixPricingRequest) throws IOException, NexmoClientException {
+        return this.prefixPricingMethod.execute(prefixPricingRequest);
+    }
+}

--- a/src/main/java/com/nexmo/client/account/PrefixPricingMethod.java
+++ b/src/main/java/com/nexmo/client/account/PrefixPricingMethod.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.auth.TokenAuthMethod;
+import com.nexmo.client.voice.endpoints.AbstractMethod;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.BasicResponseHandler;
+
+import java.io.IOException;
+
+public class PrefixPricingMethod extends AbstractMethod<PrefixPricingRequest, PrefixPricingResponse> {
+    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+
+    private static final String DEFAULT_BASE_URI = "https://rest.nexmo.com/account/get-prefix-pricing/outbound/";
+
+    private String baseUri = DEFAULT_BASE_URI;
+
+    PrefixPricingMethod(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+    }
+
+    @Override
+    protected Class[] getAcceptableAuthMethods() {
+        return ALLOWED_AUTH_METHODS;
+    }
+
+    @Override
+    public RequestBuilder makeRequest(PrefixPricingRequest prefixPricingRequest) {
+        String uri = this.baseUri + prefixPricingRequest.getServiceType().name().toLowerCase();
+        return RequestBuilder.get(uri).addParameter("prefix", prefixPricingRequest.getPrefix());
+    }
+
+    @Override
+    public PrefixPricingResponse parseResponse(HttpResponse response) throws IOException {
+        return PrefixPricingResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+    }
+}

--- a/src/main/java/com/nexmo/client/account/PrefixPricingRequest.java
+++ b/src/main/java/com/nexmo/client/account/PrefixPricingRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+public class PrefixPricingRequest {
+    private ServiceType serviceType;
+    private String prefix;
+
+    public PrefixPricingRequest(ServiceType serviceType, String prefix) {
+        if (serviceType == null) {
+            throw new IllegalArgumentException("Service type cannot be null.");
+        }
+        this.serviceType = serviceType;
+        this.prefix = prefix;
+    }
+
+    public ServiceType getServiceType() {
+        return serviceType;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+}

--- a/src/main/java/com/nexmo/client/account/PrefixPricingResponse.java
+++ b/src/main/java/com/nexmo/client/account/PrefixPricingResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexmo.client.NexmoUnexpectedException;
+
+import java.io.IOException;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PrefixPricingResponse {
+    private int count;
+    private List<PricingResponse> countries;
+
+    public int getCount() {
+        return count;
+    }
+
+    public List<PricingResponse> getCountries() {
+        return countries;
+    }
+
+    public static PrefixPricingResponse fromJson(String json) {
+        try {
+            return new ObjectMapper().readValue(json, PrefixPricingResponse.class);
+        } catch (IOException jpe) {
+            throw new NexmoUnexpectedException("Failed to produce PrefixPricingResponse from json.", jpe);
+        }
+    }
+}

--- a/src/main/java/com/nexmo/client/account/PricingEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/PricingEndpoint.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoClientException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+class PricingEndpoint {
+    private Map<ServiceType, PricingMethod> methods = new HashMap<>();
+
+    PricingEndpoint(HttpWrapper httpWrapper) {
+        this.methods.put(ServiceType.SMS, new SmsPricingMethod(httpWrapper));
+        this.methods.put(ServiceType.VOICE, new VoicePricingMethod(httpWrapper));
+    }
+
+    PricingResponse getPrice(ServiceType serviceType, PricingRequest request) throws IOException, NexmoClientException {
+        if (this.methods.containsKey(serviceType)) {
+            return this.methods.get(serviceType).execute(request);
+        }
+
+        throw new IllegalArgumentException("Unknown Service Type: " + serviceType);
+    }
+}

--- a/src/main/java/com/nexmo/client/account/PricingMethod.java
+++ b/src/main/java/com/nexmo/client/account/PricingMethod.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.auth.TokenAuthMethod;
+import com.nexmo.client.voice.endpoints.AbstractMethod;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.BasicResponseHandler;
+
+import java.io.IOException;
+
+abstract class PricingMethod extends AbstractMethod<PricingRequest, PricingResponse> {
+    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+
+    PricingMethod(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+    }
+
+    @Override
+    protected Class[] getAcceptableAuthMethods() {
+        return ALLOWED_AUTH_METHODS;
+    }
+
+    @Override
+    public RequestBuilder makeRequest(PricingRequest pricingRequest) {
+        return RequestBuilder.get(this.getUri()).addParameter("country", pricingRequest.getCountryCode());
+    }
+
+    @Override
+    public PricingResponse parseResponse(HttpResponse response) throws IOException {
+        return PricingResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+    }
+
+    abstract String getUri();
+}

--- a/src/main/java/com/nexmo/client/account/PricingRequest.java
+++ b/src/main/java/com/nexmo/client/account/PricingRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+public class PricingRequest {
+    private String countryCode;
+
+    public PricingRequest(String countryCode) {
+        this.countryCode = countryCode;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+}

--- a/src/main/java/com/nexmo/client/account/PricingResponse.java
+++ b/src/main/java/com/nexmo/client/account/PricingResponse.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexmo.client.NexmoUnexpectedException;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PricingResponse {
+    private String dialingPrefix;
+    private BigDecimal defaultPrice;
+    private String currency;
+    @JsonUnwrapped
+    private Country country;
+    private List<Network> networks;
+
+    public String getDialingPrefix() {
+        return dialingPrefix;
+    }
+
+    public BigDecimal getDefaultPrice() {
+        return defaultPrice;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public Country getCountry() {
+        return country;
+    }
+
+    public List<Network> getNetworks() {
+        return networks;
+    }
+
+    public static PricingResponse fromJson(String json) {
+        try {
+            return new ObjectMapper().readValue(json, PricingResponse.class);
+        } catch (IOException jpe) {
+            throw new NexmoUnexpectedException("Failed to produce PricingResponse from json.", jpe);
+        }
+    }
+}

--- a/src/main/java/com/nexmo/client/account/ServiceType.java
+++ b/src/main/java/com/nexmo/client/account/ServiceType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+public enum ServiceType {
+    SMS, VOICE;
+}

--- a/src/main/java/com/nexmo/client/account/SmsPricingMethod.java
+++ b/src/main/java/com/nexmo/client/account/SmsPricingMethod.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.nexmo.client.HttpWrapper;
+
+public class SmsPricingMethod extends PricingMethod {
+    private static final String DEFAULT_URI = "https://rest.nexmo.com/account/get-pricing/outbound/sms";
+
+    private String uri = DEFAULT_URI;
+
+    SmsPricingMethod(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+    }
+
+    @Override
+    String getUri() {
+        return this.uri;
+    }
+}

--- a/src/main/java/com/nexmo/client/account/VoicePricingMethod.java
+++ b/src/main/java/com/nexmo/client/account/VoicePricingMethod.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.account;
+
+import com.nexmo.client.HttpWrapper;
+
+public class VoicePricingMethod extends PricingMethod {
+    private static final String DEFAULT_URI = "https://rest.nexmo.com/account/get-pricing/outbound/voice";
+
+    private String uri = DEFAULT_URI;
+
+    VoicePricingMethod(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+    }
+
+    @Override
+    String getUri() {
+        return this.uri;
+    }
+}

--- a/src/test/java/com/nexmo/client/ClientTest.java
+++ b/src/test/java/com/nexmo/client/ClientTest.java
@@ -19,10 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.nexmo.client.verify;
+package com.nexmo.client;
 
-import com.nexmo.client.AbstractClient;
-import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;

--- a/src/test/java/com/nexmo/client/account/AccountClientTest.java
+++ b/src/test/java/com/nexmo/client/account/AccountClientTest.java
@@ -21,19 +21,24 @@
  */
 package com.nexmo.client.account;
 
+import com.nexmo.client.ClientTest;
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.auth.TokenAuthMethod;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+
 import static org.mockito.Mockito.*;
 
-public class AccountClientTest {
-    private AccountClient client;
+public class AccountClientTest extends ClientTest<AccountClient> {
     private BalanceResponse sentinel;
 
     @Before
     public void setUp() throws Exception {
-        client = new AccountClient(null);
+        wrapper = new HttpWrapper(new TokenAuthMethod("not-an-api-key", "secret"));
+        client = new AccountClient(wrapper);
         client.balance = mock(BalanceEndpoint.class);
         sentinel = new BalanceResponse(1.1, true);
         when(client.balance.execute()).thenReturn(sentinel);
@@ -46,4 +51,145 @@ public class AccountClientTest {
         Assert.assertEquals(sentinel, response);
     }
 
+    @Test
+    public void testGetSmsPrice() throws Exception {
+        String json = "{\n" + "  \"dialingPrefix\": \"1\",\n" + "  \"defaultPrice\": \"0.00570000\",\n" + "  \"currency\": \"EUR\",\n" + "  \"countryDisplayName\": \"United States of America\",\n" + "  \"countryCode\": \"US\",\n" + "  \"countryName\": \"United States\",\n" + "  \"networks\": [\n" + "    {\n" + "      \"type\": \"mobile\",\n" + "      \"price\": \"0.00570000\",\n" + "      \"currency\": \"EUR\",\n" + "      \"mcc\": \"987\",\n" + "      \"mnc\": \"123\",\n" + "      \"networkCode\": \"123456\",\n" + "      \"networkName\": \"Test Mobile\"\n" + "    },\n" + "    {\n" + "      \"type\": \"landline\",\n" + "      \"price\": \"0.00330000\",\n" + "      \"currency\": \"EUR\",\n" + "      \"mcc\": \"123\",\n" + "      \"mnc\": \"456\",\n" + "      \"networkCode\": \"networkcode\",\n" + "      \"networkName\": \"Test Landline\"\n" + "    }  \n" + "  ]\n" + "}\n";
+        wrapper.setHttpClient(this.stubHttpClient(200, json));
+        PricingResponse response = client.getSmsPrice("US");
+        Assert.assertEquals("1", response.getDialingPrefix());
+        Assert.assertEquals(new BigDecimal("0.00570000"), response.getDefaultPrice());
+        Assert.assertEquals("EUR", response.getCurrency());
+        Assert.assertEquals("United States of America", response.getCountry().getDisplayName());
+        Assert.assertEquals("US", response.getCountry().getCode());
+        Assert.assertEquals("United States", response.getCountry().getName());
+
+        Assert.assertEquals(2, response.getNetworks().size());
+        Network first = response.getNetworks().get(0);
+        Assert.assertEquals(Network.Type.MOBILE, first.getType());
+        Assert.assertEquals(new BigDecimal("0.00570000"), first.getPrice());
+        Assert.assertEquals("EUR", first.getCurrency());
+        Assert.assertEquals("987", first.getMcc());
+        Assert.assertEquals("123", first.getMnc());
+        Assert.assertEquals("123456", first.getCode());
+        Assert.assertEquals("Test Mobile", first.getName());
+
+
+        Network second = response.getNetworks().get(1);
+        Assert.assertEquals(Network.Type.LANDLINE, second.getType());
+        Assert.assertEquals(new BigDecimal("0.00330000"), second.getPrice());
+        Assert.assertEquals("EUR", second.getCurrency());
+        Assert.assertEquals("123", second.getMcc());
+        Assert.assertEquals("456", second.getMnc());
+        Assert.assertEquals("networkcode", second.getCode());
+        Assert.assertEquals("Test Landline", second.getName());
+    }
+
+    @Test
+    public void testGetVoicePrice() throws Exception {
+        String json = "{\n" + "  \"dialingPrefix\": \"1\",\n" + "  \"defaultPrice\": \"0.00570000\",\n" + "  \"currency\": \"EUR\",\n" + "  \"countryDisplayName\": \"United States of America\",\n" + "  \"countryCode\": \"US\",\n" + "  \"countryName\": \"United States\",\n" + "  \"networks\": [\n" + "    {\n" + "      \"type\": \"mobile\",\n" + "      \"price\": \"0.00570000\",\n" + "      \"currency\": \"EUR\",\n" + "      \"mcc\": \"987\",\n" + "      \"mnc\": \"123\",\n" + "      \"networkCode\": \"123456\",\n" + "      \"networkName\": \"Test Mobile\"\n" + "    },\n" + "    {\n" + "      \"type\": \"landline\",\n" + "      \"price\": \"0.00330000\",\n" + "      \"currency\": \"EUR\",\n" + "      \"mcc\": \"123\",\n" + "      \"mnc\": \"456\",\n" + "      \"networkCode\": \"networkcode\",\n" + "      \"networkName\": \"Test Landline\"\n" + "    }  \n" + "  ]\n" + "}\n";
+        wrapper.setHttpClient(this.stubHttpClient(200, json));
+        PricingResponse response = client.getVoicePrice("US");
+        Assert.assertEquals("1", response.getDialingPrefix());
+        Assert.assertEquals(new BigDecimal("0.00570000"), response.getDefaultPrice());
+        Assert.assertEquals("EUR", response.getCurrency());
+        Assert.assertEquals("United States of America", response.getCountry().getDisplayName());
+        Assert.assertEquals("US", response.getCountry().getCode());
+        Assert.assertEquals("United States", response.getCountry().getName());
+
+        Assert.assertEquals(2, response.getNetworks().size());
+        Network first = response.getNetworks().get(0);
+        Assert.assertEquals(Network.Type.MOBILE, first.getType());
+        Assert.assertEquals(new BigDecimal("0.00570000"), first.getPrice());
+        Assert.assertEquals("EUR", first.getCurrency());
+        Assert.assertEquals("987", first.getMcc());
+        Assert.assertEquals("123", first.getMnc());
+        Assert.assertEquals("123456", first.getCode());
+        Assert.assertEquals("Test Mobile", first.getName());
+
+
+        Network second = response.getNetworks().get(1);
+        Assert.assertEquals(Network.Type.LANDLINE, second.getType());
+        Assert.assertEquals(new BigDecimal("0.00330000"), second.getPrice());
+        Assert.assertEquals("EUR", second.getCurrency());
+        Assert.assertEquals("123", second.getMcc());
+        Assert.assertEquals("456", second.getMnc());
+        Assert.assertEquals("networkcode", second.getCode());
+        Assert.assertEquals("Test Landline", second.getName());
+    }
+
+    @Test
+    public void testGetPrefixVoicePrice() throws Exception {
+        String json = "{\n" + "    \"count\": 2,\n" + "    \"countries\": [\n" + "        {\n" + "            \"dialingPrefix\": \"1\",\n" + "            \"defaultPrice\": \"0.01270000\",\n" + "            \"currency\": \"EUR\",\n" + "            \"countryDisplayName\": \"Canada\",\n" + "            \"countryCode\": \"CA\",\n" + "            \"countryName\": \"Canada\",\n" + "            \"networks\": [\n" + "                {\n" + "                    \"type\": \"mobile\",\n" + "                    \"price\": \"0.01280000\",\n" + "                    \"currency\": \"EUR\",\n" + "                    \"aliases\": [\n" + "                        \"302998\"\n" + "                    ],\n" + "                    \"mcc\": \"302\",\n" + "                    \"mnc\": \"702\",\n" + "                    \"networkCode\": \"302702\",\n" + "                    \"networkName\": \"BELL ALIANT REGIONAL Communications LP\"\n" + "                },\n" + "                {\n" + "                    \"type\": \"landline\",\n" + "                    \"price\": \"0.01000000\",\n" + "                    \"currency\": \"EUR\",\n" + "                    \"networkCode\": \"CA-FIXED\",\n" + "                    \"networkName\": \"Canada Landline\"\n" + "                }\n" + "            ]\n" + "        },\n" + "        {\n" + "            \"dialingPrefix\": \"1\",\n" + "            \"currency\": \"EUR\",\n" + "            \"countryDisplayName\": \"United States Minor Outlying Islands\",\n" + "            \"countryCode\": \"UM\",\n" + "            \"countryName\": \"United States Minor Outlying Islands\"\n" + "        }\n" + "    ]\n" + "}";
+        wrapper.setHttpClient(this.stubHttpClient(200, json));
+        PrefixPricingResponse response = client.getPrefixPrice(ServiceType.VOICE, "1");
+        Assert.assertEquals(2, response.getCount());
+        Assert.assertEquals(2, response.getCountries().size());
+
+        PricingResponse firstResponse = response.getCountries().get(0);
+        Assert.assertEquals("1", firstResponse.getDialingPrefix());
+        Assert.assertEquals(new BigDecimal("0.01270000"), firstResponse.getDefaultPrice());
+        Assert.assertEquals("EUR", firstResponse.getCurrency());
+        Assert.assertEquals("Canada", firstResponse.getCountry().getDisplayName());
+        Assert.assertEquals("CA", firstResponse.getCountry().getCode());
+        Assert.assertEquals("Canada", firstResponse.getCountry().getName());
+
+        Assert.assertEquals(2, firstResponse.getNetworks().size());
+        Network firstResponseFirstNetwork = firstResponse.getNetworks().get(0);
+        Assert.assertEquals(Network.Type.MOBILE, firstResponseFirstNetwork.getType());
+        Assert.assertEquals(new BigDecimal("0.01280000"), firstResponseFirstNetwork.getPrice());
+        Assert.assertEquals("EUR", firstResponseFirstNetwork.getCurrency());
+        Assert.assertEquals("302", firstResponseFirstNetwork.getMcc());
+        Assert.assertEquals("702", firstResponseFirstNetwork.getMnc());
+        Assert.assertEquals("302702", firstResponseFirstNetwork.getCode());
+        Assert.assertEquals("BELL ALIANT REGIONAL Communications LP", firstResponseFirstNetwork.getName());
+
+
+        Network firstResponseSecondNetwork = firstResponse.getNetworks().get(1);
+        Assert.assertEquals(Network.Type.LANDLINE, firstResponseSecondNetwork.getType());
+        Assert.assertEquals(new BigDecimal("0.01000000"), firstResponseSecondNetwork.getPrice());
+        Assert.assertEquals("EUR", firstResponseSecondNetwork.getCurrency());
+        Assert.assertEquals("CA-FIXED", firstResponseSecondNetwork.getCode());
+        Assert.assertEquals("Canada Landline", firstResponseSecondNetwork.getName());
+
+        PricingResponse secondResponse = response.getCountries().get(1);
+        Assert.assertEquals("1", secondResponse.getDialingPrefix());
+        Assert.assertEquals("EUR", secondResponse.getCurrency());
+        Assert.assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getDisplayName());
+        Assert.assertEquals("UM", secondResponse.getCountry().getCode());
+        Assert.assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getName());
+    }
+
+    @Test
+    public void testGetPrefixSmsPrice() throws Exception {
+        String json = "{\n" + "    \"count\": 2,\n" + "    \"countries\": [\n" + "        {\n" + "            \"dialingPrefix\": \"1\",\n" + "            \"defaultPrice\": \"0.00570000\",\n" + "            \"currency\": \"EUR\",\n" + "            \"countryDisplayName\": \"Canada\",\n" + "            \"countryCode\": \"CA\",\n" + "            \"countryName\": \"Canada\",\n" + "            \"networks\": [\n" + "                {\n" + "                    \"type\": \"mobile\",\n" + "                    \"price\": \"0.00570000\",\n" + "                    \"currency\": \"EUR\",\n" + "                    \"aliases\": [\n" + "                        \"302660\"\n" + "                    ],\n" + "                    \"mcc\": \"302\",\n" + "                    \"mnc\": \"655\",\n" + "                    \"networkCode\": \"302655\",\n" + "                    \"networkName\": \"MTS Communications Inc.\"\n" + "                }\n" + "            ]\n" + "        },\n" + "        {\n" + "            \"dialingPrefix\": \"1\",\n" + "            \"currency\": \"EUR\",\n" + "            \"countryDisplayName\": \"United States Minor Outlying Islands\",\n" + "            \"countryCode\": \"UM\",\n" + "            \"countryName\": \"United States Minor Outlying Islands\"\n" + "        }\n" + "    ]\n" + "}";
+        wrapper.setHttpClient(this.stubHttpClient(200, json));
+        PrefixPricingResponse response = client.getPrefixPrice(ServiceType.SMS, "1");
+        Assert.assertEquals(2, response.getCount());
+        Assert.assertEquals(2, response.getCountries().size());
+
+        PricingResponse firstResponse = response.getCountries().get(0);
+        Assert.assertEquals("1", firstResponse.getDialingPrefix());
+        Assert.assertEquals(new BigDecimal("0.00570000"), firstResponse.getDefaultPrice());
+        Assert.assertEquals("EUR", firstResponse.getCurrency());
+        Assert.assertEquals("Canada", firstResponse.getCountry().getDisplayName());
+        Assert.assertEquals("CA", firstResponse.getCountry().getCode());
+        Assert.assertEquals("Canada", firstResponse.getCountry().getName());
+
+        Assert.assertEquals(1, firstResponse.getNetworks().size());
+        Network network = firstResponse.getNetworks().get(0);
+        Assert.assertEquals(Network.Type.MOBILE, network.getType());
+        Assert.assertEquals(new BigDecimal("0.00570000"), network.getPrice());
+        Assert.assertEquals("EUR", network.getCurrency());
+        Assert.assertEquals("302", network.getMcc());
+        Assert.assertEquals("655", network.getMnc());
+        Assert.assertEquals("302655", network.getCode());
+        Assert.assertEquals("MTS Communications Inc.", network.getName());
+
+        PricingResponse secondResponse = response.getCountries().get(1);
+        Assert.assertEquals("1", secondResponse.getDialingPrefix());
+        Assert.assertEquals("EUR", secondResponse.getCurrency());
+        Assert.assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getDisplayName());
+        Assert.assertEquals("UM", secondResponse.getCountry().getCode());
+        Assert.assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getName());
+    }
 }

--- a/src/test/java/com/nexmo/client/verify/VerifyClientCheckEndpointTest.java
+++ b/src/test/java/com/nexmo/client/verify/VerifyClientCheckEndpointTest.java
@@ -21,6 +21,7 @@
  */
 package com.nexmo.client.verify;
 
+import com.nexmo.client.ClientTest;
 import com.nexmo.client.NexmoResponseParseException;
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/com/nexmo/client/verify/VerifyClientSearchEndpointTest.java
+++ b/src/test/java/com/nexmo/client/verify/VerifyClientSearchEndpointTest.java
@@ -21,6 +21,7 @@
  */
 package com.nexmo.client.verify;
 
+import com.nexmo.client.ClientTest;
 import com.nexmo.client.NexmoResponseParseException;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/nexmo/client/verify/VerifyClientVerifyControlEndpointTest.java
+++ b/src/test/java/com/nexmo/client/verify/VerifyClientVerifyControlEndpointTest.java
@@ -21,6 +21,7 @@
  */
 package com.nexmo.client.verify;
 
+import com.nexmo.client.ClientTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/nexmo/client/verify/VerifyClientVerifyEndpointTest.java
+++ b/src/test/java/com/nexmo/client/verify/VerifyClientVerifyEndpointTest.java
@@ -21,6 +21,7 @@
  */
 package com.nexmo.client.verify;
 
+import com.nexmo.client.ClientTest;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
Add the ability to query the API for voice and SMS pricing via the `getVoicePrice` and `getSmsPrice` methods on the `AccountClient`.

Resolves #88 and #87.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
