### PR TITLE
Add getSms to SmsClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `getVoicePrice` to `AccountClient` for getting voice pricing for a country.
 - Added `getPrefixPrice` to `AccountClient` for getting SMS and voice pricing for a prefix.
 - Added `topUp` to `AccountClient` for topping up your account which has auto-reload enabled.
-
+- Added `getSms` to `SmsClient` for searching for a single message by id.
 ## [3.5.0] - 2018-05-29
 ### Changed
 - Updated `VerifyClient` to use the JSON endpoints instead of XML.

--- a/src/main/java/com/nexmo/client/sms/SmsClient.java
+++ b/src/main/java/com/nexmo/client/sms/SmsClient.java
@@ -43,6 +43,7 @@ public class SmsClient {
     private SendMessageEndpoint message;
     private SmsSearchEndpoint search;
     private SearchRejectedMessagesEndpoint rejected;
+    private SmsSingleSearchEndpoint singleSearch;
 
     /**
      * Create a new SmsClient.
@@ -51,6 +52,7 @@ public class SmsClient {
         this.message = new SendMessageEndpoint(httpWrapper);
         this.search = new SmsSearchEndpoint(httpWrapper);
         this.rejected = new SearchRejectedMessagesEndpoint(httpWrapper);
+        this.singleSearch = new SmsSingleSearchEndpoint(httpWrapper);
     }
 
     /**
@@ -79,8 +81,7 @@ public class SmsClient {
      * You should probably use the helper methods {@link #searchMessages(String, String...)} or
      * {@link #searchMessages(String, String...)} instead.
      */
-    public SearchSmsResponse searchMessages(SearchSmsRequest request)
-            throws IOException, NexmoClientException {
+    public SearchSmsResponse searchMessages(SearchSmsRequest request) throws IOException, NexmoClientException {
         return this.search.execute(request);
     }
 
@@ -91,8 +92,7 @@ public class SmsClient {
      * @param ids optional extra IDs to look up
      * @return SMS data matching the provided criteria
      */
-    public SearchSmsResponse searchMessages(String id, String... ids)
-            throws IOException, NexmoClientException {
+    public SearchSmsResponse searchMessages(String id, String... ids) throws IOException, NexmoClientException {
         List<String> idList = new ArrayList<>(ids.length + 1);
         idList.add(id);
         idList.addAll(Arrays.asList(ids));
@@ -106,8 +106,7 @@ public class SmsClient {
      * @param to   the MSISDN number of the SMS recipient
      * @return SMS data matching the provided criteria
      */
-    public SearchSmsResponse searchMessages(Date date, String to)
-            throws IOException, NexmoClientException {
+    public SearchSmsResponse searchMessages(Date date, String to) throws IOException, NexmoClientException {
         return this.searchMessages(new SmsDateSearchRequest(date, to));
     }
 
@@ -115,11 +114,10 @@ public class SmsClient {
      * Search for rejected SMS transactions using a {@link SearchRejectedMessagesRequest}.
      * <p>
      * You should probably use {@link #searchRejectedMessages(Date, String)} instead.
-
+     *
      * @return rejection data matching the provided criteria
      */
-    public SearchRejectedMessagesResponse searchRejectedMessages(SearchRejectedMessagesRequest request)
-            throws IOException, NexmoClientException {
+    public SearchRejectedMessagesResponse searchRejectedMessages(SearchRejectedMessagesRequest request) throws IOException, NexmoClientException {
         return this.rejected.execute(request);
     }
 
@@ -130,8 +128,20 @@ public class SmsClient {
      * @param to   the MSISDN number of the SMS recipient
      * @return rejection data matching the provided criteria
      */
-    public SearchRejectedMessagesResponse searchRejectedMessages(Date date, String to)
-            throws IOException, NexmoClientException {
+    public SearchRejectedMessagesResponse searchRejectedMessages(Date date,
+                                                                 String to) throws IOException, NexmoClientException {
         return this.searchRejectedMessages(new SearchRejectedMessagesRequest(date, to));
+    }
+
+    /**
+     * Search for a single SMS by id.
+     *
+     * @param id The message id to search for.
+     * @return SmsSingleSearchResponse object containing the details of the SMS.
+     * @throws NexmoResponseParseException if the HTTP response could not be parsed.
+     * @throws IOException                 There has been an error attempting to communicate with the Nexmo service (e.g. Network failure).
+     */
+    public SmsSingleSearchResponse getSms(String id) throws IOException, NexmoClientException {
+        return this.singleSearch.execute(id);
     }
 }

--- a/src/main/java/com/nexmo/client/sms/SmsSingleSearchEndpoint.java
+++ b/src/main/java/com/nexmo/client/sms/SmsSingleSearchEndpoint.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011-2017 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.sms;
+
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoClientException;
+import com.nexmo.client.auth.TokenAuthMethod;
+import com.nexmo.client.voice.endpoints.AbstractMethod;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.BasicResponseHandler;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+public class SmsSingleSearchEndpoint extends AbstractMethod<String, SmsSingleSearchResponse> {
+
+    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+
+    private static final String DEFAULT_URI = "https://rest.nexmo.com/search/message";
+
+    private String uri = DEFAULT_URI;
+
+    public SmsSingleSearchEndpoint(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+    }
+
+    @Override
+    protected Class[] getAcceptableAuthMethods() {
+        return ALLOWED_AUTH_METHODS;
+    }
+
+    @Override
+    public RequestBuilder makeRequest(String id) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder.get(uri);
+        requestBuilder.addParameter("id", id);
+        return requestBuilder;
+    }
+
+    @Override
+    public SmsSingleSearchResponse parseResponse(HttpResponse response) throws IOException {
+        return SmsSingleSearchResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+    }
+}

--- a/src/main/java/com/nexmo/client/sms/SmsSingleSearchResponse.java
+++ b/src/main/java/com/nexmo/client/sms/SmsSingleSearchResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.sms;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexmo.client.NexmoUnexpectedException;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+
+public class SmsSingleSearchResponse extends SmsDetails {
+    public static SmsSingleSearchResponse fromJson(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
+            return mapper.readValue(json, SmsSingleSearchResponse.class);
+        } catch (IOException jpe) {
+            throw new NexmoUnexpectedException("Failed to produce SmsSingleSearchResponse from json.", jpe);
+        }
+    }
+}

--- a/src/test/java/com/nexmo/client/sms/SmsClientTest.java
+++ b/src/test/java/com/nexmo/client/sms/SmsClientTest.java
@@ -38,12 +38,11 @@ import org.junit.Test;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -223,5 +222,37 @@ public class SmsClientTest {
                 "447700900983"
         );
         assertThat(response.getCount(), CoreMatchers.equalTo(1));
+    }
+
+    @Test
+    public void testSearchSingleMessagesId() throws Exception {
+        this.wrapper.setHttpClient(this.stubHttpClient(200, "{\n" +
+                "      \"message-id\": \"00A0B0C0\",\n" +
+                "      \"account-id\": \"key\",\n" +
+                "      \"network\": \"20810\",\n" +
+                "      \"from\": \"MyApp\",\n" +
+                "      \"to\": \"123456890\",\n" +
+                "      \"body\": \"hello world\",\n" +
+                "      \"price\": \"0.04500000\",\n" +
+                "      \"date-received\": \"2011-11-25 16:03:00\",\n" +
+                "      \"final-status\": \"DELIVRD\",\n" +
+                "      \"date-closed\": \"2011-11-25 16:03:00\",\n" +
+                "      \"latency\": 11151,\n" +
+                "      \"type\": \"MT\"\n" +
+                "    }"));
+
+        SmsSingleSearchResponse response = client.getSms("an-id");
+        assertEquals("00A0B0C0", response.getMessageId());
+        assertEquals("key", response.getAccountId());
+        assertEquals("20810", response.getNetwork());
+        assertEquals("MyApp", response.getFrom());
+        assertEquals("123456890", response.getTo());
+        assertEquals("hello world", response.getBody());
+        assertEquals("0.04500000", response.getPrice());
+        assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2011-11-25 16:03:00"), response.getDateReceived());
+        assertEquals("DELIVRD", response.getFinalStatus());
+        assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2011-11-25 16:03:00"), response.getDateClosed());
+        assertEquals(new Integer(11151), response.getLatency());
+        assertEquals("MT", response.getType());
     }
 }


### PR DESCRIPTION
Added endpoint to search messages by single id. `getSms` on the `SmsClient`.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)

Not super happy with this implementation and would like to revisit it for next major version release.