### PR TITLE
Add access to the Conversion API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `getVoicePrice` to `AccountClient` for getting voice pricing for a country.
 - Added `getPrefixPrice` to `AccountClient` for getting SMS and voice pricing for a prefix.
 - Added `topUp` to `AccountClient` for topping up your account which has auto-reload enabled.
+- Added `ConversionClient` and the ability to interact with the Nexmo Conversion API.
 
 ## [3.5.0] - 2018-05-29
 ### Changed

--- a/README.md
+++ b/README.md
@@ -241,6 +241,19 @@ AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
 NexmoClient client = new NexmoClient(auth);
 client.getAccountClient().topUp("TRANSACTION_NUMBER");
 ```
+
+### Submit Conversion
+
+Submit a request to the Conversion API when it has been enabled on your account with:
+```java
+AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
+NexmoClient client = new NexmoClient(auth);
+this.client.submitConversion(ConversionRequest.Type.VOICE,
+                                     "MESSAGE-ID",
+                                     true,
+                                     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
+```
+
 ### Custom HTTP Configuration
 
 If you need to configure the Apache HttpClient used for making requests, you can

--- a/src/main/java/com/nexmo/client/NexmoClient.java
+++ b/src/main/java/com/nexmo/client/NexmoClient.java
@@ -27,6 +27,7 @@ import com.nexmo.client.applications.ApplicationClient;
 import com.nexmo.client.auth.AuthMethod;
 import com.nexmo.client.auth.JWTAuthMethod;
 import com.nexmo.client.auth.NexmoUnacceptableAuthException;
+import com.nexmo.client.conversion.ConversionClient;
 import com.nexmo.client.insight.InsightClient;
 import com.nexmo.client.numbers.NumbersClient;
 import com.nexmo.client.sms.SmsClient;
@@ -53,6 +54,7 @@ public class NexmoClient {
     private final VoiceClient voice;
     private final VerifyClient verify;
     private final SnsClient sns;
+    private final ConversionClient conversion;
 
     private HttpWrapper httpWrapper;
 
@@ -67,6 +69,7 @@ public class NexmoClient {
         this.voice = new VoiceClient(this.httpWrapper);
         this.sms = new SmsClient(this.httpWrapper);
         this.sns = new SnsClient(this.httpWrapper);
+        this.conversion = new ConversionClient(this.httpWrapper);
     }
 
     /**
@@ -110,6 +113,10 @@ public class NexmoClient {
 
     public VoiceClient getVoiceClient() {
         return this.voice;
+    }
+
+    public ConversionClient getConversionClient() {
+        return this.conversion;
     }
 
     /**

--- a/src/main/java/com/nexmo/client/conversion/ConversionClient.java
+++ b/src/main/java/com/nexmo/client/conversion/ConversionClient.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.conversion;
+
+import com.nexmo.client.AbstractClient;
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoClient;
+import com.nexmo.client.NexmoClientException;
+
+import java.io.IOException;
+import java.util.Date;
+
+/**
+ * A client for talking to the Nexmo Conversion API. The standard way to obtain an instance of this class is to use
+ * {@link NexmoClient#getConversionClient()}.
+ * <p>
+ * Allows you to tell Nexmo about the reliability of your 2FA communications.
+ * <p>
+ * More information on method parameters can be found at Nexmo website:
+ * <a href="https://developer.nexmo.com/messaging/conversion-api/overview">https://developer.nexmo.com/messaging/conversion-api/overview</a>
+ */
+public class ConversionClient extends AbstractClient {
+    private ConversionEndpoint conversionEndpoint;
+
+    public ConversionClient(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+
+        this.conversionEndpoint = new ConversionEndpoint(httpWrapper);
+    }
+
+    /**
+     * Submit a request to the Conversion API indicating whether or not a message was delivered.
+     *
+     * @param type      The {@link ConversionRequest.Type} type of com.nexmo.client.conversion.
+     * @param messageId The id of the message that was sent.
+     * @param delivered A boolean indicating whether or not it was delivered.
+     * @param timestamp A timestamp of when it was known to be delivered.
+     * @throws IOException          if a network error occurred contacting the Nexmo Conversion API.
+     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     */
+    public void submitConversion(ConversionRequest.Type type,
+                                 String messageId,
+                                 boolean delivered,
+                                 Date timestamp) throws IOException, NexmoClientException {
+        this.conversionEndpoint.submitConversion(new ConversionRequest(type, messageId, delivered, timestamp));
+    }
+}

--- a/src/main/java/com/nexmo/client/conversion/ConversionEndpoint.java
+++ b/src/main/java/com/nexmo/client/conversion/ConversionEndpoint.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.conversion;
+
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoClientException;
+
+import java.io.IOException;
+
+class ConversionEndpoint {
+    private ConversionMethod conversionMethod;
+
+    ConversionEndpoint(HttpWrapper httpWrapper) {
+        this.conversionMethod = new ConversionMethod(httpWrapper);
+    }
+
+    void submitConversion(ConversionRequest request) throws IOException, NexmoClientException {
+        this.conversionMethod.execute(request);
+    }
+}

--- a/src/main/java/com/nexmo/client/conversion/ConversionMethod.java
+++ b/src/main/java/com/nexmo/client/conversion/ConversionMethod.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.conversion;
+
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoBadRequestException;
+import com.nexmo.client.NexmoClientException;
+import com.nexmo.client.auth.SignatureAuthMethod;
+import com.nexmo.client.auth.TokenAuthMethod;
+import com.nexmo.client.voice.endpoints.AbstractMethod;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.text.SimpleDateFormat;
+
+class ConversionMethod extends AbstractMethod<ConversionRequest, Void> {
+
+    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+
+    private static final String DEFAULT_BASE_URI = "https://api.nexmo.com/conversions/";
+
+    private String baseUri = DEFAULT_BASE_URI;
+
+    ConversionMethod(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+    }
+
+    @Override
+    protected Class[] getAcceptableAuthMethods() {
+        return ALLOWED_AUTH_METHODS;
+    }
+
+    @Override
+    public RequestBuilder makeRequest(ConversionRequest conversionRequest) throws NexmoClientException, UnsupportedEncodingException {
+        String uri = this.baseUri + conversionRequest.getType().name().toLowerCase();
+        return RequestBuilder.post(uri)
+                .addParameter("message-id", conversionRequest.getMessageId())
+                .addParameter("delivered", String.valueOf(conversionRequest.isDelivered()))
+                .addParameter("timestamp",
+                              new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(conversionRequest.getTimestamp()));
+    }
+
+    @Override
+    public Void parseResponse(HttpResponse response) throws IOException, NexmoClientException {
+        if (response.getStatusLine().getStatusCode() != 200) {
+            throw new NexmoBadRequestException(EntityUtils.toString(response.getEntity()));
+        }
+
+        return null;
+    }
+
+    public String getBaseUri() {
+        return this.baseUri;
+    }
+}

--- a/src/main/java/com/nexmo/client/conversion/ConversionRequest.java
+++ b/src/main/java/com/nexmo/client/conversion/ConversionRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.conversion;
+
+import java.util.Date;
+
+public class ConversionRequest {
+    private Type type;
+    private String messageId;
+    private boolean delivered;
+    private Date timestamp;
+
+    public ConversionRequest(Type type, String messageId, boolean delivered, Date timestamp) {
+        this.type = type;
+        this.messageId = messageId;
+        this.delivered = delivered;
+        this.timestamp = timestamp;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public boolean isDelivered() {
+        return delivered;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public enum Type {
+        SMS, VOICE
+    }
+}

--- a/src/test/java/com/nexmo/client/conversion/ConversionClientTest.java
+++ b/src/test/java/com/nexmo/client/conversion/ConversionClientTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.conversion;
+
+import com.nexmo.client.ClientTest;
+import com.nexmo.client.NexmoBadRequestException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+
+public class ConversionClientTest extends ClientTest<ConversionClient> {
+    @Before
+    public void setUp() {
+        client = new ConversionClient(wrapper);
+    }
+
+    @Test
+    public void testSuccessfulResponse() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(200, ""));
+        this.client.submitConversion(ConversionRequest.Type.VOICE,
+                                     "MESSAGE-ID",
+                                     true,
+                                     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
+    }
+
+    @Test(expected = NexmoBadRequestException.class)
+    public void testWrongCredentials() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(401, ""));
+        this.client.submitConversion(ConversionRequest.Type.SMS,
+                                     "MESSAGE-ID",
+                                     true,
+                                     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
+    }
+
+    @Test(expected = NexmoBadRequestException.class)
+    public void testConversionNotEnabled() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(402, ""));
+        this.client.submitConversion(ConversionRequest.Type.SMS,
+                                     "MESSAGE-ID",
+                                     true,
+                                     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
+    }
+
+    @Test(expected = NexmoBadRequestException.class)
+    public void testInvalidParameters() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(423, ""));
+        this.client.submitConversion(ConversionRequest.Type.SMS,
+                                     "MESSAGE-ID",
+                                     true,
+                                     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
+    }
+
+    @Test(expected = NexmoBadRequestException.class)
+    public void testInvalidParametersEnhanceCalm() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(420, ""));
+        this.client.submitConversion(ConversionRequest.Type.SMS,
+                                     "MESSAGE-ID",
+                                     true,
+                                     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
+    }
+
+
+}

--- a/src/test/java/com/nexmo/client/conversion/ConversionClientTest.java
+++ b/src/test/java/com/nexmo/client/conversion/ConversionClientTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 
 import java.text.SimpleDateFormat;
 
+import static org.junit.Assert.fail;
+
 public class ConversionClientTest extends ClientTest<ConversionClient> {
     @Before
     public void setUp() {
@@ -35,12 +37,16 @@ public class ConversionClientTest extends ClientTest<ConversionClient> {
     }
 
     @Test
-    public void testSuccessfulResponse() throws Exception {
-        wrapper.setHttpClient(this.stubHttpClient(200, ""));
-        this.client.submitConversion(ConversionRequest.Type.VOICE,
-                                     "MESSAGE-ID",
-                                     true,
-                                     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
+    public void testSuccessfulResponse() {
+        try {
+            wrapper.setHttpClient(this.stubHttpClient(200, ""));
+            this.client.submitConversion(ConversionRequest.Type.VOICE,
+                                         "MESSAGE-ID",
+                                         true,
+                                         new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
+        } catch (Exception e) {
+            fail("No exceptions should be thrown.");
+        }
     }
 
     @Test(expected = NexmoBadRequestException.class)

--- a/src/test/java/com/nexmo/client/conversion/ConversionMethodTest.java
+++ b/src/test/java/com/nexmo/client/conversion/ConversionMethodTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.conversion;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConversionMethodTest {
+    @Test
+    public void testConstructParametersWithSms() throws Exception {
+        ConversionMethod method = new ConversionMethod(null);
+        ConversionRequest request = new ConversionRequest(ConversionRequest.Type.SMS,
+                                                          "MESSAGE-ID",
+                                                          true,
+                                                          new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(
+                                                                  "2014-03-04 10:11:12"));
+        RequestBuilder requestBuilder = method.makeRequest(request);
+        List<NameValuePair> params = requestBuilder.getParameters();
+
+        assertContainsParam(params, "message-id", "MESSAGE-ID");
+        assertContainsParam(params, "delivered", "true");
+        assertContainsParam(params, "timestamp", "2014-03-04 10:11:12");
+        assertEquals(method.getBaseUri() + ConversionRequest.Type.SMS.name().toLowerCase(),
+                     requestBuilder.getUri().toString());
+    }
+
+    @Test
+    public void testConstructParametersWithVoice() throws Exception {
+        ConversionMethod method = new ConversionMethod(null);
+        ConversionRequest request = new ConversionRequest(ConversionRequest.Type.VOICE,
+                                                          "MESSAGE-ID",
+                                                          true,
+                                                          new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(
+                                                                  "2014-03-04 10:11:12"));
+        RequestBuilder requestBuilder = method.makeRequest(request);
+        List<NameValuePair> params = requestBuilder.getParameters();
+
+        assertContainsParam(params, "message-id", "MESSAGE-ID");
+        assertContainsParam(params, "delivered", "true");
+        assertContainsParam(params, "timestamp", "2014-03-04 10:11:12");
+        assertEquals(method.getBaseUri() + ConversionRequest.Type.VOICE.name().toLowerCase(),
+                     requestBuilder.getUri().toString());
+    }
+
+    private void assertContainsParam(List<NameValuePair> params, String key, String value) {
+        NameValuePair item = new BasicNameValuePair(key, value);
+        assertTrue("" + params + " should contain " + item, params.contains(item));
+    }
+}


### PR DESCRIPTION
Added the ability to interact with the [Conversion API](https://developer.nexmo.com/messaging/conversion-api/overview).

This was done in a similar fashion to the other APIs with an `Endpoint`, `Method`, and `Client`.  Interaction with the API can be done through `getConversionClient()` on the `NexmoClient`.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
