### PR TITLE
Fix Travis CI Java 7 Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: java
 
 jdk:
   - oraclejdk8
-  - openjdk7
+  - oraclejdk7
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.jvm.Jvm
+
 buildscript {
     repositories {
         jcenter()
@@ -24,7 +26,12 @@ sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
 
 repositories {
-    mavenCentral()
+    if (Jvm.current().javaVersion.toString() == "1.7") {
+        // Fall back to HTTP because the public Oracle and OpenJDK 1.7 versions don't support TLSv1.2
+        maven { url "http://repo.maven.apache.org/maven2/" }
+    } else {
+        mavenCentral()
+    }
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
As of June 18, Maven Central requires TLSv1.2. Both the `oraclejdk7` and `openjdk7` distributions in Travis CI are too old to support TLSv1.2.

I have modified our `build.gradle` file to fallback to HTTP for retrieving dependencies when building in a Java 7 environment.

See: https://central.sonatype.org/articles/2018/May/04/discontinue-support-for-tlsv11-and-below/