### PR TITLE
Add Support for Redact API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Development]
+### Added
+- Added `RedactClient` and the ability to interact with the Nexmo Redact API.
+
 ## [3.6.0] - 2018-07-06
 ### Added
 - Added `getSmsPrice` to `AccountClient` for getting SMS pricing for a country.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,24 @@ this.client.submitConversion(ConversionRequest.Type.VOICE,
                                      new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
 ```
 
+### Redact Inbound SMS
+
+Submit a request to the Redact API when it has been enabled on your account with:
+```java
+AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
+NexmoClient client = new NexmoClient(auth);
+client.getRedactClient().transaction(SMS_ID, RedactRequest.Product.SMS, RedactRequest.Type.INBOUND);
+```
+
+### Redact Voice
+
+Submit a request to the Redact API when it has been enabled on your account with:
+```java
+AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
+NexmoClient client = new NexmoClient(auth);
+client.getRedactClient().transaction(VOICE_ID, RedactRequest.Product.VOICE);
+```
+
 ### Custom HTTP Configuration
 
 If you need to configure the Apache HttpClient used for making requests, you can

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Submit a request to the Redact API when it has been enabled on your account with
 ```java
 AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
 NexmoClient client = new NexmoClient(auth);
-client.getRedactClient().transaction(SMS_ID, RedactRequest.Product.SMS, RedactRequest.Type.INBOUND);
+client.getRedactClient().redactTransaction(SMS_ID, RedactRequest.Product.SMS, RedactRequest.Type.INBOUND);
 ```
 
 ### Redact Voice
@@ -269,7 +269,7 @@ Submit a request to the Redact API when it has been enabled on your account with
 ```java
 AuthMethod auth = new TokenAuthMethod(API_KEY, API_SECRET);
 NexmoClient client = new NexmoClient(auth);
-client.getRedactClient().transaction(VOICE_ID, RedactRequest.Product.VOICE);
+client.getRedactClient().redactTransaction(VOICE_ID, RedactRequest.Product.VOICE);
 ```
 
 ### Custom HTTP Configuration

--- a/src/main/java/com/nexmo/client/NexmoClient.java
+++ b/src/main/java/com/nexmo/client/NexmoClient.java
@@ -30,6 +30,7 @@ import com.nexmo.client.auth.NexmoUnacceptableAuthException;
 import com.nexmo.client.conversion.ConversionClient;
 import com.nexmo.client.insight.InsightClient;
 import com.nexmo.client.numbers.NumbersClient;
+import com.nexmo.client.redact.RedactClient;
 import com.nexmo.client.sms.SmsClient;
 import com.nexmo.client.sns.SnsClient;
 import com.nexmo.client.verify.VerifyClient;
@@ -55,6 +56,7 @@ public class NexmoClient {
     private final VerifyClient verify;
     private final SnsClient sns;
     private final ConversionClient conversion;
+    private final RedactClient redact;
 
     private HttpWrapper httpWrapper;
 
@@ -70,6 +72,7 @@ public class NexmoClient {
         this.sms = new SmsClient(this.httpWrapper);
         this.sns = new SnsClient(this.httpWrapper);
         this.conversion = new ConversionClient(this.httpWrapper);
+        this.redact = new RedactClient(this.httpWrapper);
     }
 
     /**
@@ -119,10 +122,15 @@ public class NexmoClient {
         return this.conversion;
     }
 
+    public RedactClient getRedactClient() {
+        return this.redact;
+    }
+
     /**
      * Generate a JWT for the application the client has been configured with.
      *
      * @return A String containing the token data.
+     *
      * @throws NexmoUnacceptableAuthException if no {@link JWTAuthMethod} is available
      */
     public String generateJwt() throws NexmoUnacceptableAuthException {

--- a/src/main/java/com/nexmo/client/auth/AbstractAuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/AbstractAuthMethod.java
@@ -21,6 +21,7 @@
  */
 package com.nexmo.client.auth;
 
+import org.apache.http.client.methods.RequestBuilder;
 
 public abstract class AbstractAuthMethod implements AuthMethod {
     @Override
@@ -29,4 +30,10 @@ public abstract class AbstractAuthMethod implements AuthMethod {
     }
 
     public abstract int getSortKey();
+
+    @Override
+    public RequestBuilder applyAsBasicAuth(RequestBuilder request) {
+        throw new UnsupportedOperationException(
+                "applyAsBasicAuth not implemented for " + this.getClass().getCanonicalName());
+    }
 }

--- a/src/main/java/com/nexmo/client/auth/AuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/AuthMethod.java
@@ -27,5 +27,14 @@ import org.apache.http.client.methods.RequestBuilder;
 public interface AuthMethod extends Comparable<AuthMethod> {
     public RequestBuilder apply(RequestBuilder request);
 
+    /**
+     * Apply the authentication to the header as basic authentication.
+     *
+     * @param requestBuilder The request being built
+     *
+     * @return RequestBuilder for more building of the request.
+     */
+    public RequestBuilder applyAsBasicAuth(RequestBuilder requestBuilder);
+
     public int getSortKey();
 }

--- a/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
@@ -21,7 +21,10 @@
  */
 package com.nexmo.client.auth;
 
+import com.sun.org.apache.xml.internal.security.utils.Base64;
+import org.apache.http.Header;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.message.BasicHeader;
 
 public class TokenAuthMethod extends AbstractAuthMethod {
     public final int SORT_KEY = 30;
@@ -36,9 +39,14 @@ public class TokenAuthMethod extends AbstractAuthMethod {
 
     @Override
     public RequestBuilder apply(RequestBuilder request) {
-        return request
-                .addParameter("api_key", this.apiKey)
-                .addParameter("api_secret", this.apiSecret);
+        return request.addParameter("api_key", this.apiKey).addParameter("api_secret", this.apiSecret);
+    }
+
+    @Override
+    public RequestBuilder applyAsBasicAuth(RequestBuilder request) {
+        String headerValue = Base64.encode((this.apiKey + ":" + this.apiSecret).getBytes());
+        Header authHeader = new BasicHeader("Authorization", "Basic " + headerValue);
+        return request.addHeader(authHeader);
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
@@ -21,7 +21,7 @@
  */
 package com.nexmo.client.auth;
 
-import com.sun.org.apache.xml.internal.security.utils.Base64;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.message.BasicHeader;
@@ -44,7 +44,7 @@ public class TokenAuthMethod extends AbstractAuthMethod {
 
     @Override
     public RequestBuilder applyAsBasicAuth(RequestBuilder request) {
-        String headerValue = Base64.encode((this.apiKey + ":" + this.apiSecret).getBytes());
+        String headerValue = Base64.encodeBase64String((this.apiKey + ":" + this.apiSecret).getBytes());
         Header authHeader = new BasicHeader("Authorization", "Basic " + headerValue);
         return request.addHeader(authHeader);
     }

--- a/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
@@ -27,7 +27,7 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.message.BasicHeader;
 
 public class TokenAuthMethod extends AbstractAuthMethod {
-    public final int SORT_KEY = 30;
+    private final int SORT_KEY = 30;
 
     private String apiKey;
     private String apiSecret;

--- a/src/main/java/com/nexmo/client/redact/RedactClient.java
+++ b/src/main/java/com/nexmo/client/redact/RedactClient.java
@@ -23,7 +23,15 @@ package com.nexmo.client.redact;
 
 import com.nexmo.client.AbstractClient;
 import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoClient;
+import com.nexmo.client.NexmoClientException;
 
+import java.io.IOException;
+
+/**
+ * A client for talking to the Nexmo Redact API. The standard way to obtain an instance of this class is to use
+ * {@link NexmoClient#getRedactClient()}.
+ */
 public class RedactClient extends AbstractClient {
     private RedactEndpoint redactEndpoint;
 
@@ -31,5 +39,47 @@ public class RedactClient extends AbstractClient {
         super(httpWrapper);
 
         this.redactEndpoint = new RedactEndpoint(httpWrapper);
+    }
+
+    /**
+     * Submit a request to the Redact API to redact a transaction.
+     *
+     * @param id      The transaction id to redact.
+     * @param product The {@link com.nexmo.client.redact.RedactRequest.Product} which corresponds to the transaction.
+     *
+     * @throws IOException          if a network error occurred contacting the Nexmo Redact API.
+     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     */
+    public void transaction(String id, RedactRequest.Product product) throws IOException, NexmoClientException {
+        this.transaction(new RedactRequest(id, product));
+    }
+
+    /**
+     * Submit a request to the Redact API to redact a transaction.
+     *
+     * @param id      The transaction id to redact.
+     * @param product The {@link com.nexmo.client.redact.RedactRequest.Product} which corresponds to the transaction.
+     * @param type    The {@link com.nexmo.client.redact.RedactRequest.Type} which is required if redacting SMS data.
+     *
+     * @throws IOException          if a network error occurred contacting the Nexmo Redact API.
+     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     */
+    public void transaction(String id, RedactRequest.Product product, RedactRequest.Type type) throws IOException, NexmoClientException {
+        RedactRequest request = new RedactRequest(id, product);
+        request.setType(type);
+
+        this.transaction(request);
+    }
+
+    /**
+     * Submit a request to the Redact API to redact a transaction.
+     *
+     * @param redactRequest a {@link RedactRequest} object which contains the request parameters.
+     *
+     * @throws IOException          if a network error occurred contacting the Nexmo Redact API.
+     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     */
+    public void transaction(RedactRequest redactRequest) throws IOException, NexmoClientException {
+        this.redactEndpoint.transaction(redactRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/redact/RedactClient.java
+++ b/src/main/java/com/nexmo/client/redact/RedactClient.java
@@ -50,8 +50,8 @@ public class RedactClient extends AbstractClient {
      * @throws IOException          if a network error occurred contacting the Nexmo Redact API.
      * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
      */
-    public void transaction(String id, RedactRequest.Product product) throws IOException, NexmoClientException {
-        this.transaction(new RedactRequest(id, product));
+    public void redactTransaction(String id, RedactRequest.Product product) throws IOException, NexmoClientException {
+        this.redactTransaction(new RedactRequest(id, product));
     }
 
     /**
@@ -64,11 +64,11 @@ public class RedactClient extends AbstractClient {
      * @throws IOException          if a network error occurred contacting the Nexmo Redact API.
      * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
      */
-    public void transaction(String id, RedactRequest.Product product, RedactRequest.Type type) throws IOException, NexmoClientException {
+    public void redactTransaction(String id, RedactRequest.Product product, RedactRequest.Type type) throws IOException, NexmoClientException {
         RedactRequest request = new RedactRequest(id, product);
         request.setType(type);
 
-        this.transaction(request);
+        this.redactTransaction(request);
     }
 
     /**
@@ -79,7 +79,7 @@ public class RedactClient extends AbstractClient {
      * @throws IOException          if a network error occurred contacting the Nexmo Redact API.
      * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
      */
-    public void transaction(RedactRequest redactRequest) throws IOException, NexmoClientException {
-        this.redactEndpoint.transaction(redactRequest);
+    public void redactTransaction(RedactRequest redactRequest) throws IOException, NexmoClientException {
+        this.redactEndpoint.redactTransaction(redactRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/redact/RedactClient.java
+++ b/src/main/java/com/nexmo/client/redact/RedactClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.redact;
+
+import com.nexmo.client.AbstractClient;
+import com.nexmo.client.HttpWrapper;
+
+public class RedactClient extends AbstractClient {
+    private RedactEndpoint redactEndpoint;
+
+    public RedactClient(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+
+        this.redactEndpoint = new RedactEndpoint(httpWrapper);
+    }
+}

--- a/src/main/java/com/nexmo/client/redact/RedactEndpoint.java
+++ b/src/main/java/com/nexmo/client/redact/RedactEndpoint.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.redact;
+
+import com.nexmo.client.HttpWrapper;
+
+public class RedactEndpoint {
+    private RedactMethod redactMethod;
+    public RedactEndpoint(HttpWrapper httpWrapper) {
+
+    }
+}

--- a/src/main/java/com/nexmo/client/redact/RedactEndpoint.java
+++ b/src/main/java/com/nexmo/client/redact/RedactEndpoint.java
@@ -22,10 +22,18 @@
 package com.nexmo.client.redact;
 
 import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoClientException;
 
-public class RedactEndpoint {
+import java.io.IOException;
+
+class RedactEndpoint {
     private RedactMethod redactMethod;
-    public RedactEndpoint(HttpWrapper httpWrapper) {
 
+    RedactEndpoint(HttpWrapper httpWrapper) {
+        this.redactMethod = new RedactMethod(httpWrapper);
+    }
+
+    void transaction(RedactRequest redactRequest) throws IOException, NexmoClientException {
+        this.redactMethod.execute(redactRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/redact/RedactEndpoint.java
+++ b/src/main/java/com/nexmo/client/redact/RedactEndpoint.java
@@ -33,7 +33,7 @@ class RedactEndpoint {
         this.redactMethod = new RedactMethod(httpWrapper);
     }
 
-    void transaction(RedactRequest redactRequest) throws IOException, NexmoClientException {
+    void redactTransaction(RedactRequest redactRequest) throws IOException, NexmoClientException {
         this.redactMethod.execute(redactRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/redact/RedactMethod.java
+++ b/src/main/java/com/nexmo/client/redact/RedactMethod.java
@@ -76,7 +76,7 @@ public class RedactMethod extends AbstractMethod<RedactRequest, RedactResponse> 
     }
 
     @Override
-    protected boolean isUseBasicAuth() {
-        return true;
+    protected RequestBuilder applyAuth(RequestBuilder request) throws NexmoClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
     }
 }

--- a/src/main/java/com/nexmo/client/redact/RedactMethod.java
+++ b/src/main/java/com/nexmo/client/redact/RedactMethod.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.redact;
+
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoClientException;
+import com.nexmo.client.auth.SignatureAuthMethod;
+import com.nexmo.client.auth.TokenAuthMethod;
+import com.nexmo.client.voice.endpoints.AbstractMethod;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+public class RedactMethod extends AbstractMethod<RedactRequest, RedactResponse> {
+    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+
+    private static final String DEFAULT_URI = "https://api.nexmo.com/verify/json";
+
+    private String uri = DEFAULT_URI;
+
+    public RedactMethod(HttpWrapper httpWrapper) {
+        super(httpWrapper);
+    }
+
+    @Override
+    protected Class[] getAcceptableAuthMethods() {
+        return ALLOWED_AUTH_METHODS;
+    }
+
+    @Override
+    public RequestBuilder makeRequest(RedactRequest request) throws NexmoClientException, UnsupportedEncodingException {
+        return null;
+    }
+
+    @Override
+    public RedactResponse parseResponse(HttpResponse response) throws IOException, NexmoClientException {
+        return null;
+    }
+}

--- a/src/main/java/com/nexmo/client/redact/RedactRequest.java
+++ b/src/main/java/com/nexmo/client/redact/RedactRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.redact;
+
+public class RedactRequest {
+}

--- a/src/main/java/com/nexmo/client/redact/RedactRequest.java
+++ b/src/main/java/com/nexmo/client/redact/RedactRequest.java
@@ -21,5 +21,93 @@
  */
 package com.nexmo.client.redact;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexmo.client.NexmoUnexpectedException;
+
+/**
+ * Represents a request to the Redact API.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RedactRequest {
+
+    private String id;
+    private Product product;
+    private Type type;
+
+    /**
+     * Construct a RedactRequest object with all required fields.
+     *
+     * @param id      The transaction id to redact.
+     * @param product The {@link Product} that the id relates to.
+     */
+    public RedactRequest(String id, Product product) {
+        this.id = id;
+        this.product = product;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public String toJson() {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException jpe) {
+            throw new NexmoUnexpectedException("Failed to produce json from RedactRequest object.", jpe);
+        }
+    }
+
+    public enum Product {
+        SMS("sms"),
+        VOICE("voice"),
+        NUMBER_INSIGHTS("number-insight"),
+        VERIFY("verify"),
+        VERIFY_SDK("verify-sdk"),
+        MESSAGE("message"),
+        WORKFLOW("workflow");
+
+        private String value;
+
+        Product(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public enum Type {
+        INBOUND, OUTBOUND;
+
+        @JsonValue
+        public String getValue() {
+            return this.name().toLowerCase();
+        }
+    }
 }

--- a/src/main/java/com/nexmo/client/redact/RedactResponse.java
+++ b/src/main/java/com/nexmo/client/redact/RedactResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.redact;
+
+public class RedactResponse {
+}

--- a/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
@@ -122,11 +122,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
      * @throws NexmoClientException If no appropriate {@link AuthMethod} is available
      */
     protected RequestBuilder applyAuth(RequestBuilder request) throws NexmoClientException {
-        AuthMethod authMethod = getAuthMethod(getAcceptableAuthMethods());
-        if (isUseBasicAuth()) {
-            return authMethod.applyAsBasicAuth(request);
-        }
-        return authMethod.apply(request);
+        return getAuthMethod(getAcceptableAuthMethods()).apply(request);
     }
 
     /**
@@ -178,12 +174,4 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
      * @throws IOException if a problem occurs parsing the response
      */
     public abstract ResultT parseResponse(HttpResponse response) throws IOException, NexmoClientException;
-
-    /**
-     * Indicates whether or not basic authentication should be used.
-     * Workaround for implementation of AbstractMethod where parameter authentication is not supported.
-     */
-    protected boolean isUseBasicAuth() {
-        return false;
-    }
 }

--- a/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
@@ -40,6 +40,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -92,7 +93,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
             if (httpRequest instanceof HttpEntityEnclosingRequest) {
                 HttpEntityEnclosingRequest entityRequest = (HttpEntityEnclosingRequest) httpRequest;
                 HttpEntity entity = entityRequest.getEntity();
-                if (entity != null && entity instanceof UrlEncodedFormEntity) {
+                if (entity instanceof UrlEncodedFormEntity) {
                     entityRequest.setEntity(new UrlEncodedFormEntity(requestBuilder.getParameters(),
                             Charset.forName("UTF-8")
                     ));
@@ -138,9 +139,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
     protected AuthMethod getAuthMethod(Class[] acceptableAuthMethods) throws NexmoClientException {
         if (acceptable == null) {
             this.acceptable = new HashSet<>();
-            for (Class c : acceptableAuthMethods) {
-                acceptable.add(c);
-            }
+            Collections.addAll(acceptable, acceptableAuthMethods);
         }
 
         return this.httpWrapper.getAuthCollection().getAcceptableAuthMethod(acceptable);

--- a/src/test/java/com/nexmo/client/redact/RedactClientTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactClientTest.java
@@ -42,7 +42,6 @@ public class RedactClientTest extends ClientTest<RedactClient> {
             redactRequest.setType(RedactRequest.Type.INBOUND);
 
             this.client.transaction(redactRequest);
-            this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
             this.client.transaction(redactRequest.getId(), redactRequest.getProduct(), redactRequest.getType());
         } catch (Exception e) {
             fail("No exceptions should be thrown.");
@@ -52,7 +51,7 @@ public class RedactClientTest extends ClientTest<RedactClient> {
     @Test(expected = NexmoBadRequestException.class)
     public void testWrongCredentials() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(401, ""));
-        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
         this.client.transaction(redactRequest);
         this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
     }
@@ -60,7 +59,7 @@ public class RedactClientTest extends ClientTest<RedactClient> {
     @Test(expected = NexmoBadRequestException.class)
     public void testPrematureRedactionOrUnauthorized() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(403, ""));
-        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
         this.client.transaction(redactRequest);
         this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
     }
@@ -68,7 +67,7 @@ public class RedactClientTest extends ClientTest<RedactClient> {
     @Test(expected = NexmoBadRequestException.class)
     public void testInvalidId() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(404, ""));
-        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
         this.client.transaction(redactRequest);
         this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
     }
@@ -76,7 +75,7 @@ public class RedactClientTest extends ClientTest<RedactClient> {
     @Test(expected = NexmoBadRequestException.class)
     public void testInvalidJsonInvalidProduct() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(422, ""));
-        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
         this.client.transaction(redactRequest);
         this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
     }
@@ -84,7 +83,7 @@ public class RedactClientTest extends ClientTest<RedactClient> {
     @Test(expected = NexmoBadRequestException.class)
     public void testRateLimit() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(429, ""));
-        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
         this.client.transaction(redactRequest);
         this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
     }

--- a/src/test/java/com/nexmo/client/redact/RedactClientTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactClientTest.java
@@ -41,8 +41,8 @@ public class RedactClientTest extends ClientTest<RedactClient> {
             RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
             redactRequest.setType(RedactRequest.Type.INBOUND);
 
-            this.client.transaction(redactRequest);
-            this.client.transaction(redactRequest.getId(), redactRequest.getProduct(), redactRequest.getType());
+            this.client.redactTransaction(redactRequest);
+            this.client.redactTransaction(redactRequest.getId(), redactRequest.getProduct(), redactRequest.getType());
         } catch (Exception e) {
             fail("No exceptions should be thrown.");
         }
@@ -52,40 +52,40 @@ public class RedactClientTest extends ClientTest<RedactClient> {
     public void testWrongCredentials() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(401, ""));
         RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
-        this.client.transaction(redactRequest);
-        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+        this.client.redactTransaction(redactRequest);
+        this.client.redactTransaction(redactRequest.getId(), redactRequest.getProduct());
     }
 
     @Test(expected = NexmoBadRequestException.class)
     public void testPrematureRedactionOrUnauthorized() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(403, ""));
         RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
-        this.client.transaction(redactRequest);
-        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+        this.client.redactTransaction(redactRequest);
+        this.client.redactTransaction(redactRequest.getId(), redactRequest.getProduct());
     }
 
     @Test(expected = NexmoBadRequestException.class)
     public void testInvalidId() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(404, ""));
         RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
-        this.client.transaction(redactRequest);
-        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+        this.client.redactTransaction(redactRequest);
+        this.client.redactTransaction(redactRequest.getId(), redactRequest.getProduct());
     }
 
     @Test(expected = NexmoBadRequestException.class)
     public void testInvalidJsonInvalidProduct() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(422, ""));
         RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
-        this.client.transaction(redactRequest);
-        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+        this.client.redactTransaction(redactRequest);
+        this.client.redactTransaction(redactRequest.getId(), redactRequest.getProduct());
     }
 
     @Test(expected = NexmoBadRequestException.class)
     public void testRateLimit() throws Exception {
         wrapper.setHttpClient(this.stubHttpClient(429, ""));
         RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
-        this.client.transaction(redactRequest);
-        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+        this.client.redactTransaction(redactRequest);
+        this.client.redactTransaction(redactRequest.getId(), redactRequest.getProduct());
     }
 
 }

--- a/src/test/java/com/nexmo/client/redact/RedactClientTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactClientTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.redact;
+
+import com.nexmo.client.ClientTest;
+import com.nexmo.client.NexmoBadRequestException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class RedactClientTest extends ClientTest<RedactClient> {
+    @Before
+    public void setUp() {
+        client = new RedactClient(wrapper);
+    }
+
+    @Test
+    public void testSuccessfulResponse() {
+        try {
+            wrapper.setHttpClient(this.stubHttpClient(204, ""));
+            RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+            redactRequest.setType(RedactRequest.Type.INBOUND);
+
+            this.client.transaction(redactRequest);
+            this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+            this.client.transaction(redactRequest.getId(), redactRequest.getProduct(), redactRequest.getType());
+        } catch (Exception e) {
+            fail("No exceptions should be thrown.");
+        }
+    }
+
+    @Test(expected = NexmoBadRequestException.class)
+    public void testWrongCredentials() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(401, ""));
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        this.client.transaction(redactRequest);
+        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+    }
+
+    @Test(expected = NexmoBadRequestException.class)
+    public void testPrematureRedactionOrUnauthorized() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(403, ""));
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        this.client.transaction(redactRequest);
+        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+    }
+
+    @Test(expected = NexmoBadRequestException.class)
+    public void testInvalidId() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(404, ""));
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        this.client.transaction(redactRequest);
+        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+    }
+
+    @Test(expected = NexmoBadRequestException.class)
+    public void testInvalidJsonInvalidProduct() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(422, ""));
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        this.client.transaction(redactRequest);
+        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+    }
+
+    @Test(expected = NexmoBadRequestException.class)
+    public void testRateLimit() throws Exception {
+        wrapper.setHttpClient(this.stubHttpClient(429, ""));
+        RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        this.client.transaction(redactRequest);
+        this.client.transaction(redactRequest.getId(), redactRequest.getProduct());
+    }
+
+}

--- a/src/test/java/com/nexmo/client/redact/RedactMethodTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactMethodTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.redact;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class RedactMethodTest {
+    @Test
+    public void testConstructParamsWithoutType() throws Exception {
+        RedactMethod method = new RedactMethod(null);
+        RedactRequest request = new RedactRequest("test-id", RedactRequest.Product.VOICE);
+
+        RequestBuilder builder = method.makeRequest(request);
+        HttpEntity entity = builder.getEntity();
+
+        assertEquals(entity.getContentType().getValue(), ContentType.APPLICATION_JSON.toString());
+        assertNotNull(entity.getContent());
+    }
+
+    @Test
+    public void testConstructParamsWithType() throws Exception {
+        RedactMethod method = new RedactMethod(null);
+        RedactRequest request = new RedactRequest("test-id", RedactRequest.Product.SMS);
+        request.setType(RedactRequest.Type.INBOUND);
+
+        RequestBuilder builder = method.makeRequest(request);
+        HttpEntity entity = builder.getEntity();
+
+        assertEquals(entity.getContentType().getValue(), ContentType.APPLICATION_JSON.toString());
+        assertNotNull(entity.getContent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructParamsWithMissingId() throws Exception {
+        RedactMethod method = new RedactMethod(null);
+        RedactRequest request = new RedactRequest(null, RedactRequest.Product.SMS);
+
+        method.makeRequest(request);
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructParamsWithMissingProduct() throws Exception {
+        RedactMethod method = new RedactMethod(null);
+        RedactRequest request = new RedactRequest("test-id", null);
+
+        method.makeRequest(request);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructParamsWithMissingTypeAndSmsProduct() throws Exception {
+        RedactMethod method = new RedactMethod(null);
+        RedactRequest request = new RedactRequest("test-id", RedactRequest.Product.SMS);
+
+        method.makeRequest(request);
+    }
+}

--- a/src/test/java/com/nexmo/client/redact/RedactRequestTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactRequestTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.redact;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RedactRequestTest {
+
+    @Test
+    public void testRequiredParams() {
+        String json = "{\"id\":\"testId\",\"product\":\"voice\"}";
+        assertEquals(new RedactRequest("testId", RedactRequest.Product.VOICE).toJson(), json);
+    }
+
+    @Test
+    public void testTypeParamOutbound() {
+        String json = "{\"id\":\"testId\",\"product\":\"sms\",\"type\":\"outbound\"}";
+        RedactRequest request = new RedactRequest("testId", RedactRequest.Product.SMS);
+        request.setType(RedactRequest.Type.OUTBOUND);
+
+        assertEquals(request.toJson(), json);
+    }
+
+    @Test
+    public void testTypeParamInbound() {
+        String json = "{\"id\":\"testId\",\"product\":\"sms\",\"type\":\"inbound\"}";
+        RedactRequest request = new RedactRequest("testId", RedactRequest.Product.SMS);
+        request.setType(RedactRequest.Type.INBOUND);
+
+        assertEquals(request.toJson(), json);
+    }
+
+    @Test
+    public void testProductVoice() {
+        String json = "{\"id\":\"testId\",\"product\":\"voice\"}";
+        assertEquals(new RedactRequest("testId", RedactRequest.Product.VOICE).toJson(), json);
+    }
+
+    @Test
+    public void testProductNumberInsight() {
+        String json = "{\"id\":\"testId\",\"product\":\"number-insight\"}";
+        assertEquals(new RedactRequest("testId", RedactRequest.Product.NUMBER_INSIGHTS).toJson(), json);
+    }
+
+    @Test
+    public void testProductVerify() {
+        String json = "{\"id\":\"testId\",\"product\":\"verify\"}";
+        assertEquals(new RedactRequest("testId", RedactRequest.Product.VERIFY).toJson(), json);
+    }
+
+    @Test
+    public void testProductVerifySdk() {
+        String json = "{\"id\":\"testId\",\"product\":\"verify-sdk\"}";
+        assertEquals(new RedactRequest("testId", RedactRequest.Product.VERIFY_SDK).toJson(), json);
+    }
+
+    @Test
+    public void testProductMessage() {
+        String json = "{\"id\":\"testId\",\"product\":\"message\"}";
+        assertEquals(new RedactRequest("testId", RedactRequest.Product.MESSAGE).toJson(), json);
+    }
+
+    @Test
+    public void testProductWorkflow() {
+        String json = "{\"id\":\"testId\",\"product\":\"workflow\"}";
+        assertEquals(new RedactRequest("testId", RedactRequest.Product.WORKFLOW).toJson(), json);
+    }
+}


### PR DESCRIPTION
Added `RedactClient` to support the [Redact API](https://developer.nexmo.com/api/redact). This API works a bit differently so here's some things of note/concern:

## Authentication
Authentication is done through basic authentication parameters. I added a method to the `AuthMethod` interface called `applyAsBasicAuth`. This method is implemented to throw an `UnsupportedOperationException`. It was done this way because `AbstractMethod` uses `AuthMethod` in its logic and needed visibility of both `apply` and `applyAsBasicAuth`.

Additionally, a method was added to `AbstractMethod` called `isUseBasicAuth` which defaults to `false`. This allows extending classes to instruct `AbstractMethod` to use basic authentication parameters when constructing the request instead of standard request parameters.

## POST Payload
The POST body of this request is `application/json` so `RedactRequest` can be serialized into the request. This deviates from our other endpoints.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
