### PR TITLE
Add fallback values to enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - User Agent String now includes the Java version in addition to the client version.
+- `enum` classes that are used to deserialize JSON have been updated to return an `UNKNOWN` value instead of throwing an `IllegalArgumentException` when the value cannot be deserialized. These `enum`s are:
+    - `RecordingFormat`
+    - `MachineDetection`
+    - `ModifyCallAction`
+    - `CallDirection`
+    - `CallStatus`
+    - `RoamingDetails.RoamingStatus`
+    - `AdvancedInsightResponse.PortedStatus`
+    - `AdvancedInsightResponse.Validity`
+    - `AdvancedInsightResponse.Reachability`
 
 ### Fixed
 - Updated `StreamNcco`'s `streamUrl` to serialize into an array for use in the Voice API.

--- a/src/main/java/com/nexmo/client/insight/RoamingDetails.java
+++ b/src/main/java/com/nexmo/client/insight/RoamingDetails.java
@@ -31,17 +31,17 @@ public class RoamingDetails {
     public enum RoamingStatus {
         UNKNOWN, ROAMING, NOT_ROAMING;
 
-        private static final Map<String, RoamingStatus> roamingStatusIndex = new HashMap<>();
+        private static final Map<String, RoamingStatus> ROAMING_STATUS_INDEX = new HashMap<>();
 
         static {
             for (RoamingStatus roamingStatus : RoamingStatus.values()) {
-                roamingStatusIndex.put(roamingStatus.name(), roamingStatus);
+                ROAMING_STATUS_INDEX.put(roamingStatus.name(), roamingStatus);
             }
         }
 
         @JsonCreator
         public static RoamingStatus fromString(String name) {
-            RoamingStatus foundRoamingStatus = roamingStatusIndex.get(name.toUpperCase());
+            RoamingStatus foundRoamingStatus = ROAMING_STATUS_INDEX.get(name.toUpperCase());
             return (foundRoamingStatus != null) ? foundRoamingStatus : UNKNOWN;
         }
     }

--- a/src/main/java/com/nexmo/client/insight/RoamingDetails.java
+++ b/src/main/java/com/nexmo/client/insight/RoamingDetails.java
@@ -24,15 +24,25 @@ package com.nexmo.client.insight;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class RoamingDetails {
     public enum RoamingStatus {
-        UNKNOWN,
-        ROAMING,
-        NOT_ROAMING;
+        UNKNOWN, ROAMING, NOT_ROAMING;
+
+        private static final Map<String, RoamingStatus> roamingStatusIndex = new HashMap<>();
+
+        static {
+            for (RoamingStatus roamingStatus : RoamingStatus.values()) {
+                roamingStatusIndex.put(roamingStatus.name(), roamingStatus);
+            }
+        }
 
         @JsonCreator
         public static RoamingStatus fromString(String name) {
-            return RoamingStatus.valueOf(name.toUpperCase());
+            RoamingStatus foundRoamingStatus = roamingStatusIndex.get(name.toUpperCase());
+            return (foundRoamingStatus != null) ? foundRoamingStatus : UNKNOWN;
         }
     }
 

--- a/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightResponse.java
+++ b/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightResponse.java
@@ -31,6 +31,8 @@ import com.nexmo.client.insight.RoamingDetails;
 import com.nexmo.client.insight.standard.StandardInsightResponse;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AdvancedInsightResponse extends StandardInsightResponse {
@@ -104,41 +106,57 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
     }
 
     public enum PortedStatus {
-        UNKNOWN,
-        PORTED,
-        NOT_PORTED,
-        ASSUMED_NOT_PORTED,
-        ASSUMED_PORTED;
+        UNKNOWN, PORTED, NOT_PORTED, ASSUMED_NOT_PORTED, ASSUMED_PORTED;
+
+        private static final Map<String, PortedStatus> portedStatusIndex = new HashMap<>();
+
+        static {
+            for (PortedStatus portedStatus : PortedStatus.values()) {
+                portedStatusIndex.put(portedStatus.name(), portedStatus);
+            }
+        }
 
         @JsonCreator
         public static PortedStatus fromString(String name) {
-            return PortedStatus.valueOf(name.toUpperCase());
+            PortedStatus foundPortedStatus = portedStatusIndex.get(name.toUpperCase());
+            return (foundPortedStatus != null) ? foundPortedStatus : UNKNOWN;
         }
 
     }
 
     public enum Validity {
-        UNKNOWN,
-        VALID,
-        NOT_VALID;
+        UNKNOWN, VALID, NOT_VALID;
+
+        private static final Map<String, Validity> validityIndex = new HashMap<>();
+
+        static {
+            for (Validity validity : Validity.values()) {
+                validityIndex.put(validity.name(), validity);
+            }
+        }
 
         @JsonCreator
         public static Validity fromString(String name) {
-            return Validity.valueOf(name.toUpperCase());
+            Validity foundValidity = validityIndex.get(name.toUpperCase());
+            return (foundValidity != null) ? foundValidity : Validity.UNKNOWN;
         }
     }
 
     public enum Reachability {
-        UNKNOWN,
-        REACHABLE,
-        UNDELIVERABLE,
-        ABSENT,
-        BAD_NUMBER,
-        BLACKLISTED;
+        UNKNOWN, REACHABLE, UNDELIVERABLE, ABSENT, BAD_NUMBER, BLACKLISTED;
+
+        private static final Map<String, Reachability> reachabilityIndex = new HashMap<>();
+
+        static {
+            for (Reachability reachability : Reachability.values()) {
+                reachabilityIndex.put(reachability.name(), reachability);
+            }
+        }
 
         @JsonCreator
         public static Reachability fromString(String name) {
-            return Reachability.valueOf(name.toUpperCase());
+            Reachability foundReachability = reachabilityIndex.get(name.toUpperCase());
+            return (foundReachability != null) ? foundReachability : UNKNOWN;
         }
     }
 }

--- a/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightResponse.java
+++ b/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightResponse.java
@@ -108,17 +108,17 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
     public enum PortedStatus {
         UNKNOWN, PORTED, NOT_PORTED, ASSUMED_NOT_PORTED, ASSUMED_PORTED;
 
-        private static final Map<String, PortedStatus> portedStatusIndex = new HashMap<>();
+        private static final Map<String, PortedStatus> PORTED_STATUS_INDEX = new HashMap<>();
 
         static {
             for (PortedStatus portedStatus : PortedStatus.values()) {
-                portedStatusIndex.put(portedStatus.name(), portedStatus);
+                PORTED_STATUS_INDEX.put(portedStatus.name(), portedStatus);
             }
         }
 
         @JsonCreator
         public static PortedStatus fromString(String name) {
-            PortedStatus foundPortedStatus = portedStatusIndex.get(name.toUpperCase());
+            PortedStatus foundPortedStatus = PORTED_STATUS_INDEX.get(name.toUpperCase());
             return (foundPortedStatus != null) ? foundPortedStatus : UNKNOWN;
         }
 
@@ -127,17 +127,17 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
     public enum Validity {
         UNKNOWN, VALID, NOT_VALID;
 
-        private static final Map<String, Validity> validityIndex = new HashMap<>();
+        private static final Map<String, Validity> VALIDITY_INDEX = new HashMap<>();
 
         static {
             for (Validity validity : Validity.values()) {
-                validityIndex.put(validity.name(), validity);
+                VALIDITY_INDEX.put(validity.name(), validity);
             }
         }
 
         @JsonCreator
         public static Validity fromString(String name) {
-            Validity foundValidity = validityIndex.get(name.toUpperCase());
+            Validity foundValidity = VALIDITY_INDEX.get(name.toUpperCase());
             return (foundValidity != null) ? foundValidity : Validity.UNKNOWN;
         }
     }
@@ -145,17 +145,17 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
     public enum Reachability {
         UNKNOWN, REACHABLE, UNDELIVERABLE, ABSENT, BAD_NUMBER, BLACKLISTED;
 
-        private static final Map<String, Reachability> reachabilityIndex = new HashMap<>();
+        private static final Map<String, Reachability> REACHABILITY_INDEX = new HashMap<>();
 
         static {
             for (Reachability reachability : Reachability.values()) {
-                reachabilityIndex.put(reachability.name(), reachability);
+                REACHABILITY_INDEX.put(reachability.name(), reachability);
             }
         }
 
         @JsonCreator
         public static Reachability fromString(String name) {
-            Reachability foundReachability = reachabilityIndex.get(name.toUpperCase());
+            Reachability foundReachability = REACHABILITY_INDEX.get(name.toUpperCase());
             return (foundReachability != null) ? foundReachability : UNKNOWN;
         }
     }

--- a/src/main/java/com/nexmo/client/voice/CallDirection.java
+++ b/src/main/java/com/nexmo/client/voice/CallDirection.java
@@ -24,9 +24,21 @@ package com.nexmo.client.voice;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum CallDirection {
     OUTBOUND,
-    INBOUND;
+    INBOUND,
+    UNKNOWN;
+
+    private static final Map<String, CallDirection> callDirectionIndex = new HashMap<>();
+
+    static {
+        for (CallDirection callDirection : CallDirection.values()) {
+            callDirectionIndex.put(callDirection.name(), callDirection);
+        }
+    }
 
     @JsonValue
     @Override
@@ -36,6 +48,7 @@ public enum CallDirection {
 
     @JsonCreator
     public static CallDirection fromString(String name) {
-        return CallDirection.valueOf(name.toUpperCase());
+        CallDirection foundCallDirection = callDirectionIndex.get(name.toUpperCase());
+        return (foundCallDirection != null) ? foundCallDirection : UNKNOWN;
     }
 }

--- a/src/main/java/com/nexmo/client/voice/CallDirection.java
+++ b/src/main/java/com/nexmo/client/voice/CallDirection.java
@@ -32,11 +32,11 @@ public enum CallDirection {
     INBOUND,
     UNKNOWN;
 
-    private static final Map<String, CallDirection> callDirectionIndex = new HashMap<>();
+    private static final Map<String, CallDirection> CALL_DIRECTION_INDEX = new HashMap<>();
 
     static {
         for (CallDirection callDirection : CallDirection.values()) {
-            callDirectionIndex.put(callDirection.name(), callDirection);
+            CALL_DIRECTION_INDEX.put(callDirection.name(), callDirection);
         }
     }
 
@@ -48,7 +48,7 @@ public enum CallDirection {
 
     @JsonCreator
     public static CallDirection fromString(String name) {
-        CallDirection foundCallDirection = callDirectionIndex.get(name.toUpperCase());
+        CallDirection foundCallDirection = CALL_DIRECTION_INDEX.get(name.toUpperCase());
         return (foundCallDirection != null) ? foundCallDirection : UNKNOWN;
     }
 }

--- a/src/main/java/com/nexmo/client/voice/CallStatus.java
+++ b/src/main/java/com/nexmo/client/voice/CallStatus.java
@@ -40,11 +40,11 @@ public enum CallStatus {
     CANCELLED,
     UNKNOWN;
 
-    private static final Map<String, CallStatus> callStatusIndex = new HashMap<>();
+    private static final Map<String, CallStatus> CALL_STATUS_INDEX = new HashMap<>();
 
     static {
         for (CallStatus callStatus : CallStatus.values()) {
-            callStatusIndex.put(callStatus.name(), callStatus);
+            CALL_STATUS_INDEX.put(callStatus.name(), callStatus);
         }
     }
 
@@ -56,7 +56,7 @@ public enum CallStatus {
 
     @JsonCreator
     public static CallStatus fromString(String name) {
-        CallStatus foundCallStatus = callStatusIndex.get(name.toUpperCase());
+        CallStatus foundCallStatus = CALL_STATUS_INDEX.get(name.toUpperCase());
         return (foundCallStatus != null) ? foundCallStatus : UNKNOWN;
     }
 }

--- a/src/main/java/com/nexmo/client/voice/CallStatus.java
+++ b/src/main/java/com/nexmo/client/voice/CallStatus.java
@@ -24,6 +24,9 @@ package com.nexmo.client.voice;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum CallStatus {
     STARTED,
     RINGING,
@@ -34,7 +37,16 @@ public enum CallStatus {
     FAILED,
     REJECTED,
     BUSY,
-    CANCELLED;
+    CANCELLED,
+    UNKNOWN;
+
+    private static final Map<String, CallStatus> callStatusIndex = new HashMap<>();
+
+    static {
+        for (CallStatus callStatus : CallStatus.values()) {
+            callStatusIndex.put(callStatus.name(), callStatus);
+        }
+    }
 
     @JsonValue
     @Override
@@ -44,6 +56,7 @@ public enum CallStatus {
 
     @JsonCreator
     public static CallStatus fromString(String name) {
-        return CallStatus.valueOf(name.toUpperCase());
+        CallStatus foundCallStatus = callStatusIndex.get(name.toUpperCase());
+        return (foundCallStatus != null) ? foundCallStatus : UNKNOWN;
     }
 }

--- a/src/main/java/com/nexmo/client/voice/MachineDetection.java
+++ b/src/main/java/com/nexmo/client/voice/MachineDetection.java
@@ -30,11 +30,11 @@ import java.util.Map;
 public enum MachineDetection {
     CONTINUE, HANGUP, UNKNOWN;
 
-    private static final Map<String, MachineDetection> machineDetectionIndex = new HashMap<>();
+    private static final Map<String, MachineDetection> MACHINE_DETECTION_INDEX = new HashMap<>();
 
     static {
         for (MachineDetection machineDetection : MachineDetection.values()) {
-            machineDetectionIndex.put(machineDetection.name(), machineDetection);
+            MACHINE_DETECTION_INDEX.put(machineDetection.name(), machineDetection);
         }
     }
 
@@ -46,7 +46,7 @@ public enum MachineDetection {
 
     @JsonCreator
     public static MachineDetection fromString(String name) {
-        MachineDetection foundMachineDetection = machineDetectionIndex.get(name.toUpperCase());
+        MachineDetection foundMachineDetection = MACHINE_DETECTION_INDEX.get(name.toUpperCase());
         return (foundMachineDetection != null) ? foundMachineDetection : UNKNOWN;
     }
 }

--- a/src/main/java/com/nexmo/client/voice/ModifyCallAction.java
+++ b/src/main/java/com/nexmo/client/voice/ModifyCallAction.java
@@ -30,11 +30,11 @@ import java.util.Map;
 public enum ModifyCallAction {
     HANGUP, MUTE, UNMUTE, EARMUFF, UNEARMUFF, TRANSFER, UNKNOWN;
 
-    private static final Map<String, ModifyCallAction> modifyCallActionIndex = new HashMap<>();
+    private static final Map<String, ModifyCallAction> MODIFY_CALL_ACTION_INDEX = new HashMap<>();
 
     static {
         for (ModifyCallAction modifyCallAction : ModifyCallAction.values()) {
-            modifyCallActionIndex.put(modifyCallAction.name(), modifyCallAction);
+            MODIFY_CALL_ACTION_INDEX.put(modifyCallAction.name(), modifyCallAction);
         }
     }
 
@@ -46,7 +46,7 @@ public enum ModifyCallAction {
 
     @JsonCreator
     public static ModifyCallAction fromString(String name) {
-        ModifyCallAction foundModifyCallAction = modifyCallActionIndex.get(name.toUpperCase());
+        ModifyCallAction foundModifyCallAction = MODIFY_CALL_ACTION_INDEX.get(name.toUpperCase());
         return (foundModifyCallAction != null) ? foundModifyCallAction : UNKNOWN;
     }
 }

--- a/src/main/java/com/nexmo/client/voice/VoiceName.java
+++ b/src/main/java/com/nexmo/client/voice/VoiceName.java
@@ -25,6 +25,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Voice used to deliver text to a {@link Call} in a {@link TalkRequest}.
  */
@@ -78,7 +81,16 @@ public enum VoiceName {
     MAXIM,
     TATYANA,
     ASTRID,
-    FILIZ;
+    FILIZ,
+    UNKNOWN;
+
+    private static final Map<String, VoiceName> voiceNameIndex = new HashMap<>();
+
+    static {
+        for (VoiceName voiceName : VoiceName.values()) {
+            voiceNameIndex.put(voiceName.name(), voiceName);
+        }
+    }
 
     @JsonValue
     @Override
@@ -89,7 +101,8 @@ public enum VoiceName {
 
     @JsonCreator
     public static VoiceName fromString(String name) {
-        return VoiceName.valueOf(name.toUpperCase());
+        VoiceName foundVoiceName = voiceNameIndex.get(name.toUpperCase());
+        return (foundVoiceName != null) ? foundVoiceName : UNKNOWN;
     }
 
 }

--- a/src/main/java/com/nexmo/client/voice/ncco/RecordingFormat.java
+++ b/src/main/java/com/nexmo/client/voice/ncco/RecordingFormat.java
@@ -24,9 +24,19 @@ package com.nexmo.client.voice.ncco;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum RecordingFormat {
-    MP3,
-    WAV;
+    MP3, WAV, UNKNOWN;
+
+    private static final Map<String, RecordingFormat> recordingFormatIndex = new HashMap<>();
+
+    static {
+        for (RecordingFormat recordingFormat : RecordingFormat.values()) {
+            recordingFormatIndex.put(recordingFormat.name(), recordingFormat);
+        }
+    }
 
     @JsonValue
     @Override
@@ -36,6 +46,7 @@ public enum RecordingFormat {
 
     @JsonCreator
     public static RecordingFormat fromString(String name) {
-        return RecordingFormat.valueOf(name.toUpperCase());
+        RecordingFormat foundRecordingFormat = recordingFormatIndex.get(name.toUpperCase());
+        return (foundRecordingFormat != null) ? foundRecordingFormat : UNKNOWN;
     }
 }

--- a/src/main/java/com/nexmo/client/voice/ncco/RecordingFormat.java
+++ b/src/main/java/com/nexmo/client/voice/ncco/RecordingFormat.java
@@ -30,11 +30,11 @@ import java.util.Map;
 public enum RecordingFormat {
     MP3, WAV, UNKNOWN;
 
-    private static final Map<String, RecordingFormat> recordingFormatIndex = new HashMap<>();
+    private static final Map<String, RecordingFormat> RECORDING_FORMAT_INDEX = new HashMap<>();
 
     static {
         for (RecordingFormat recordingFormat : RecordingFormat.values()) {
-            recordingFormatIndex.put(recordingFormat.name(), recordingFormat);
+            RECORDING_FORMAT_INDEX.put(recordingFormat.name(), recordingFormat);
         }
     }
 
@@ -46,7 +46,7 @@ public enum RecordingFormat {
 
     @JsonCreator
     public static RecordingFormat fromString(String name) {
-        RecordingFormat foundRecordingFormat = recordingFormatIndex.get(name.toUpperCase());
+        RecordingFormat foundRecordingFormat = RECORDING_FORMAT_INDEX.get(name.toUpperCase());
         return (foundRecordingFormat != null) ? foundRecordingFormat : UNKNOWN;
     }
 }

--- a/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightResponseTest.java
+++ b/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightResponseTest.java
@@ -108,6 +108,26 @@ public class AdvancedInsightResponseTest {
     }
 
     @Test
+    public void testDeserializeUnknownEnumsFallbackToUnknown() throws Exception {
+        AdvancedInsightResponse response = AdvancedInsightResponse.fromJson("{\n" +
+                "    \"valid_number\": \"failed_validity\",\n" +
+                "    \"reachable\": \"failed_reachibility\",\n" +
+                "    \"ported\": \"failure_ported_status\",\n" +
+                "  \"roaming\": {\n" +
+                "    \"status\": \"failure_roaming_status\",\n" +
+                "    \"roaming_country_code\": \"GB\",\n" +
+                "    \"roaming_network_code\": \"gong\",\n" +
+                "    \"roaming_network_name\": \"Gong Telecommunications\"\n" +
+                "  }\n" +
+                "}");
+
+        assertEquals(AdvancedInsightResponse.Validity.UNKNOWN, response.getValidNumber());
+        assertEquals(AdvancedInsightResponse.Reachability.UNKNOWN, response.getReachability());
+        assertEquals(AdvancedInsightResponse.PortedStatus.UNKNOWN, response.getPorted());
+        assertEquals(RoamingDetails.RoamingStatus.UNKNOWN, response.getRoaming().getStatus());
+    }
+
+    @Test
     public void testRoamingDeserialization() throws Exception {
         AdvancedInsightResponse response = AdvancedInsightResponse.fromJson("{\n" +
                 "  \"status\": 0,\n" +

--- a/src/test/java/com/nexmo/client/voice/MachineDetectionTest.java
+++ b/src/test/java/com/nexmo/client/voice/MachineDetectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Nexmo Inc
+ * Copyright (c) 2011-2018 Nexmo Inc
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,32 +21,18 @@
  */
 package com.nexmo.client.voice;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import static org.junit.Assert.assertEquals;
 
-public enum MachineDetection {
-    CONTINUE, HANGUP, UNKNOWN;
-
-    private static final Map<String, MachineDetection> machineDetectionIndex = new HashMap<>();
-
-    static {
-        for (MachineDetection machineDetection : MachineDetection.values()) {
-            machineDetectionIndex.put(machineDetection.name(), machineDetection);
-        }
+public class MachineDetectionTest {
+    @Test
+    public void testMachineDetectionFromString() {
+        assertEquals(MachineDetection.HANGUP, MachineDetection.fromString("hangup"));
     }
 
-    @JsonValue
-    @Override
-    public String toString() {
-        return name().toLowerCase();
-    }
-
-    @JsonCreator
-    public static MachineDetection fromString(String name) {
-        MachineDetection foundMachineDetection = machineDetectionIndex.get(name.toUpperCase());
-        return (foundMachineDetection != null) ? foundMachineDetection : UNKNOWN;
+    @Test
+    public void testDeserializeUnknownEnumsFallbackToUnknown() {
+        assertEquals(MachineDetection.UNKNOWN, MachineDetection.fromString("test unknown machine detection"));
     }
 }

--- a/src/test/java/com/nexmo/client/voice/ModifyCallActionTest.java
+++ b/src/test/java/com/nexmo/client/voice/ModifyCallActionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Nexmo Inc
+ * Copyright (c) 2011-2018 Nexmo Inc
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,32 +21,14 @@
  */
 package com.nexmo.client.voice;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import static org.junit.Assert.assertEquals;
 
-public enum ModifyCallAction {
-    HANGUP, MUTE, UNMUTE, EARMUFF, UNEARMUFF, TRANSFER, UNKNOWN;
-
-    private static final Map<String, ModifyCallAction> modifyCallActionIndex = new HashMap<>();
-
-    static {
-        for (ModifyCallAction modifyCallAction : ModifyCallAction.values()) {
-            modifyCallActionIndex.put(modifyCallAction.name(), modifyCallAction);
-        }
+public class ModifyCallActionTest {
+    @Test
+    public void testDeserializeUnknownEnumsFallbackToUnknown() {
+        assertEquals(ModifyCallAction.UNKNOWN, ModifyCallAction.fromString("test unknwon action"));
     }
 
-    @JsonValue
-    @Override
-    public String toString() {
-        return name().toLowerCase();
-    }
-
-    @JsonCreator
-    public static ModifyCallAction fromString(String name) {
-        ModifyCallAction foundModifyCallAction = modifyCallActionIndex.get(name.toUpperCase());
-        return (foundModifyCallAction != null) ? foundModifyCallAction : UNKNOWN;
-    }
 }

--- a/src/test/java/com/nexmo/client/voice/VoiceNameTest.java
+++ b/src/test/java/com/nexmo/client/voice/VoiceNameTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.voice;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VoiceNameTest {
+    @Test
+    public void testGetVoiceNameFromString() {
+        assertEquals(VoiceName.CARLA, VoiceName.fromString("Carla"));
+    }
+
+    @Test
+    public void testDeserializeUnknownEnumsFallbackToUnknown() {
+        assertEquals(VoiceName.UNKNOWN, VoiceName.fromString("Test Unknown Voice Name"));
+    }
+}

--- a/src/test/java/com/nexmo/client/voice/endpoints/CallInfoTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/CallInfoTest.java
@@ -115,6 +115,39 @@ public class CallInfoTest {
         assertEquals(new PhoneEndpoint("447700900105"), record.getFrom());
     }
 
+    @Test
+    public void testDeserializeUnknownEnumsFallbackToUnknown() throws Exception {
+        String json = "{\n" +
+                "  \"uuid\": \"93137ee3-580e-45f7-a61a-e0b5716000ef\",\n" +
+                "  \"status\": \"test-unknown-call-status\",\n" +
+                "  \"direction\": \"test-unknown-direction\",\n" +
+                "  \"rate\": \"0.02400000\",\n" +
+                "  \"price\": \"0.00280000\",\n" +
+                "  \"duration\": \"7\",\n" +
+                "  \"network\": \"23410\",\n" +
+                "  \"conversation_uuid\": \"aa17bd11-c895-4225-840d-30dc38c31e50\",\n" +
+                "  \"start_time\": \"2017-01-13T13:55:02.000Z\",\n" +
+                "  \"end_time\": \"2017-01-13T13:55:09.000Z\",\n" +
+                "  \"to\": {\n" +
+                "    \"type\": \"phone\",\n" +
+                "    \"number\": \"447700900104\"\n" +
+                "  },\n" +
+                "  \"from\": {\n" +
+                "    \"type\": \"phone\",\n" +
+                "    \"number\": \"447700900105\"\n" +
+                "  },\n" +
+                "  \"_links\": {\n" +
+                "    \"self\": {\n" +
+                "      \"href\": \"/v1/calls/93137ee3-580e-45f7-a61a-e0b5716000ef\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n";
+        CallInfo record = new ObjectMapper().readValue(json, CallInfo.class);
+
+        assertEquals(CallStatus.UNKNOWN, record.getStatus());
+        assertEquals(CallDirection.UNKNOWN, record.getDirection());
+    }
+
 
     @Test
     public void testStatusStarted() throws Exception {

--- a/src/test/java/com/nexmo/client/voice/ncco/RecordingFormatTest.java
+++ b/src/test/java/com/nexmo/client/voice/ncco/RecordingFormatTest.java
@@ -23,13 +23,14 @@ package com.nexmo.client.voice.ncco;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class RecordingFormatTest {
     @Test
     public void testFromString() throws Exception {
         assertEquals(RecordingFormat.MP3, RecordingFormat.fromString("mp3"));
         assertEquals(RecordingFormat.WAV, RecordingFormat.fromString("wav"));
+        assertEquals(RecordingFormat.UNKNOWN, RecordingFormat.fromString("test unknown"));
     }
 
     @Test


### PR DESCRIPTION
Enums that are used for deserialization of JSON should fallback to a default `UNKNOWN` value instead of throwing an `IllegalArgumentException`. This allows for graceful failing in instances where the API and the library are out of sync with available values.

### Why not return `null` instead of unknown?

- `null` cannot be used in a switch statement when switching over enumerations without getting an NPE.
- Returning `null` could mean more work on the utilization side in regards to avoid NPEs. The idea here is to fail gracefully.
- This is a good application of the [Null Object Pattern](https://en.wikipedia.org/wiki/Null_object_pattern#Java)

Resolves #186 

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
