### PR TITLE
Add Data Objects for Various Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `com.nexmo.client.incoming.MessageEvent` to assist with the deserialization of the JSON payload used for incoming messages.
 - Added `com.nexmo.client.incoming.CallEvent` to assist with the deserialization of the JSON payload used for call events.
 - Added `com.nexmo.client.incoming.InputEvent` to assist with the deserialization of the JSON payload used for input events.
+- Added `com.nexmo.client.incoming.RecordEvent` to assist with the deserialization of the JSON payload used for record events.
 
 ### Changed
 - User Agent String now includes the Java version in addition to the client version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Development]
 ### Added
 - Added `com.nexmo.client.incoming.MessageEvent` to assist with the deserialization of the JSON payload used for incoming messages.
+- Added `com.nexmo.client.incoming.CallEvent` to assist with the deserialization of the JSON payload used for call events.
 
 ### Changed
 - User Agent String now includes the Java version in addition to the client version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added `com.nexmo.client.incoming.MessageEvent` to assist with the deserialization of the JSON payload used for incoming messages.
 - Added `com.nexmo.client.incoming.CallEvent` to assist with the deserialization of the JSON payload used for call events.
+- Added `com.nexmo.client.incoming.InputEvent` to assist with the deserialization of the JSON payload used for input events.
 
 ### Changed
 - User Agent String now includes the Java version in addition to the client version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Development]
+### Added
+- Added `com.nexmo.client.incoming.MessageEvent` to assist with the deserialization of the JSON payload used for incoming messages.
 
 ### Changed
 - User Agent String now includes the Java version in addition to the client version.

--- a/src/main/java/com/nexmo/client/incoming/CallDirection.java
+++ b/src/main/java/com/nexmo/client/incoming/CallDirection.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum CallDirection {
+    OUTBOUND, INBOUND, UNKNOWN;
+
+    private static final Map<String, CallDirection> CALL_DIRECTION_INDEX = new HashMap<>();
+
+    static {
+        for (CallDirection callDirection : CallDirection.values()) {
+            CALL_DIRECTION_INDEX.put(callDirection.name(), callDirection);
+        }
+    }
+
+    @JsonCreator
+    public static CallDirection fromString(String name) {
+        CallDirection foundCallDirection = CALL_DIRECTION_INDEX.get(name.toUpperCase());
+        return (foundCallDirection != null) ? foundCallDirection : UNKNOWN;
+    }
+}

--- a/src/main/java/com/nexmo/client/incoming/CallEvent.java
+++ b/src/main/java/com/nexmo/client/incoming/CallEvent.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexmo.client.NexmoUnexpectedException;
+
+import java.io.IOException;
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CallEvent {
+    private String conversationUuid;
+    private CallDirection direction;
+    private String from;
+    private CallStatus status;
+    private Date timestamp;
+    private String to;
+    private String uuid;
+
+    @JsonProperty("conversation_uuid")
+    public String getConversationUuid() {
+        return conversationUuid;
+    }
+
+    public CallDirection getDirection() {
+        return direction;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public CallStatus getStatus() {
+        return status;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public static CallEvent fromJson(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, CallEvent.class);
+        } catch (IOException jpe) {
+            throw new NexmoUnexpectedException("Failed to produce CallEvent from json.", jpe);
+        }
+    }
+}

--- a/src/main/java/com/nexmo/client/incoming/CallStatus.java
+++ b/src/main/java/com/nexmo/client/incoming/CallStatus.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum CallStatus {
+    STARTED,
+    RINGING,
+    ANSWERED,
+    COMPLETED,
+    MACHINE,
+    HUMAN,
+    INPUT,
+    BUSY,
+    CANCELLED,
+    FAILED,
+    RECORDING,
+    REJECTED,
+    TIMEOUT,
+    UNANSWERED,
+    UNKNOWN;
+
+    private static final Map<String, CallStatus> CALL_STATUS_INDEX = new HashMap<>();
+
+    static {
+        for (CallStatus callStatus : CallStatus.values()) {
+            CALL_STATUS_INDEX.put(callStatus.name(), callStatus);
+        }
+    }
+
+    @JsonCreator
+    public static CallStatus fromString(String status) {
+        CallStatus foundCallStatus = CALL_STATUS_INDEX.get(status.toUpperCase());
+        return (foundCallStatus != null) ? foundCallStatus : UNKNOWN;
+    }
+}

--- a/src/main/java/com/nexmo/client/incoming/InputEvent.java
+++ b/src/main/java/com/nexmo/client/incoming/InputEvent.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexmo.client.NexmoUnexpectedException;
+
+import java.io.IOException;
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InputEvent {
+    private String uuid;
+    private String conversationUuid;
+    private boolean timedOut;
+    private String dtmf;
+    private Date timestamp;
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    @JsonProperty("conversation_uuid")
+    public String getConversationUuid() {
+        return conversationUuid;
+    }
+
+    @JsonProperty("timed_out")
+    public boolean isTimedOut() {
+        return timedOut;
+    }
+
+    public String getDtmf() {
+        return dtmf;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public static InputEvent fromJson(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, InputEvent.class);
+        } catch (IOException jpe) {
+            throw new NexmoUnexpectedException("Failed to produce InputEvent from json.", jpe);
+        }
+    }
+}

--- a/src/main/java/com/nexmo/client/incoming/MessageEvent.java
+++ b/src/main/java/com/nexmo/client/incoming/MessageEvent.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexmo.client.NexmoUnexpectedException;
+
+import java.io.IOException;
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MessageEvent {
+    private String msisdn;
+    private String to;
+    private String messageId;
+    private String text;
+    private MessageType type;
+    private String keyword;
+    private Date messageTimestamp;
+    private String timestamp;
+    private String nonce;
+    private Boolean concat;
+    private int concatRef;
+    private int concatTotal;
+    private int concatPart;
+    private String data;
+    private String udh;
+
+    public String getMsisdn() {
+        return msisdn;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public MessageType getType() {
+        return type;
+    }
+
+    public String getKeyword() {
+        return keyword;
+    }
+
+    @JsonProperty("message-timestamp")
+    public Date getMessageTimestamp() {
+        return messageTimestamp;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public String getNonce() {
+        return nonce;
+    }
+
+    public Boolean getConcat() {
+        return concat;
+    }
+
+    @JsonProperty("concat-ref")
+    public int getConcatRef() {
+        return concatRef;
+    }
+
+    @JsonProperty("concat-total")
+    public int getConcatTotal() {
+        return concatTotal;
+    }
+
+    @JsonProperty("concat-part")
+    public int getConcatPart() {
+        return concatPart;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public String getUdh() {
+        return udh;
+    }
+
+    public static MessageEvent fromJson(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, MessageEvent.class);
+        } catch (IOException jpe) {
+            throw new NexmoUnexpectedException("Failed to produce MessageEvent from json.", jpe);
+        }
+    }
+}

--- a/src/main/java/com/nexmo/client/incoming/MessageType.java
+++ b/src/main/java/com/nexmo/client/incoming/MessageType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum MessageType {
+    TEXT, UNICODE, BINARY, UNKNOWN;
+
+    private static final Map<String, MessageType> MESSAGE_TYPE_INDEX = new HashMap<>();
+
+    static {
+        for (MessageType messageType : MessageType.values()) {
+            MESSAGE_TYPE_INDEX.put(messageType.name(), messageType);
+        }
+    }
+
+    @JsonCreator
+    public static MessageType fromString(String name) {
+        MessageType foundMessageType = MESSAGE_TYPE_INDEX.get(name.toUpperCase());
+        return (foundMessageType != null) ? foundMessageType : UNKNOWN;
+    }
+}

--- a/src/main/java/com/nexmo/client/incoming/RecordEvent.java
+++ b/src/main/java/com/nexmo/client/incoming/RecordEvent.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexmo.client.NexmoUnexpectedException;
+
+import java.io.IOException;
+import java.util.Date;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RecordEvent {
+    private Date startTime;
+    private String url;
+    private int size;
+    private String uuid;
+    private Date endTime;
+    private String conversationUuid;
+    private Date timestamp;
+
+    @JsonProperty("start_time")
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    @JsonProperty("recording_url")
+    public String getUrl() {
+        return url;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    @JsonProperty("recording_uuid")
+    public String getUuid() {
+        return uuid;
+    }
+
+    @JsonProperty("end_time")
+    public Date getEndTime() {
+        return endTime;
+    }
+
+    @JsonProperty("conversation_uuid")
+    public String getConversationUuid() {
+        return conversationUuid;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public static RecordEvent fromJson(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(json, RecordEvent.class);
+        } catch (IOException jpe) {
+            throw new NexmoUnexpectedException("Failed to produce RecordEvent from json.", jpe);
+        }
+    }
+}

--- a/src/test/java/com/nexmo/client/incoming/CallDirectionTest.java
+++ b/src/test/java/com/nexmo/client/incoming/CallDirectionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CallDirectionTest {
+    @Test
+    public void testCallDirectionFromString() {
+        assertEquals(CallDirection.OUTBOUND, CallDirection.fromString("outbound"));
+    }
+
+    @Test
+    public void testDeserializeUnknownEnumsFallbackToUnknown() {
+        assertEquals(CallDirection.UNKNOWN, CallDirection.fromString("test"));
+    }
+}

--- a/src/test/java/com/nexmo/client/incoming/CallEventTest.java
+++ b/src/test/java/com/nexmo/client/incoming/CallEventTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class CallEventTest {
+    @Test
+    public void testDeserializeCallEvent() {
+        String json = "{\n" + "    \"conversation_uuid\": \"CON-4bf66420-d6cb-46e0-9ba9-f7eede9a7301\",\n"
+                + "    \"direction\": \"inbound\",\n" + "    \"from\": \"447700900000\",\n"
+                + "    \"status\": \"started\",\n" + "    \"timestamp\": \"2018-08-14T11:07:01.284Z\",\n"
+                + "    \"to\": \"447700900001\",\n" + "    \"uuid\": \"688fd94bd0e1f59c36a4cbd36312fc28\"\n" + "}";
+
+        CallEvent callEvent = CallEvent.fromJson(json);
+        assertEquals("CON-4bf66420-d6cb-46e0-9ba9-f7eede9a7301", callEvent.getConversationUuid());
+        assertEquals(CallDirection.INBOUND, callEvent.getDirection());
+        assertEquals("447700900000", callEvent.getFrom());
+        assertEquals(CallStatus.STARTED, callEvent.getStatus());
+        assertEquals("447700900001", callEvent.getTo());
+        assertEquals("688fd94bd0e1f59c36a4cbd36312fc28", callEvent.getUuid());
+
+        Calendar calendar = new GregorianCalendar(2018, Calendar.AUGUST, 14, 11, 7, 1);
+        calendar.set(Calendar.MILLISECOND, 284);
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        assertEquals(calendar.getTime(), callEvent.getTimestamp());
+
+    }
+}

--- a/src/test/java/com/nexmo/client/incoming/CallStatusTest.java
+++ b/src/test/java/com/nexmo/client/incoming/CallStatusTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CallStatusTest {
+    @Test
+    public void testCallDirectionFromString() {
+        assertEquals(CallStatus.FAILED, CallStatus.fromString("failed"));
+    }
+
+    @Test
+    public void testDeserializeUnknownEnumsFallbackToUnknown() {
+        assertEquals(CallStatus.UNKNOWN, CallStatus.fromString("test"));
+    }
+}

--- a/src/test/java/com/nexmo/client/incoming/InputEventTest.java
+++ b/src/test/java/com/nexmo/client/incoming/InputEventTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InputEventTest {
+    @Test
+    public void testDeserializeInputEvent() {
+        String json = "{\n" + "  \"uuid\": \"aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n"
+                + "  \"conversation_uuid\": \"bbbbbbbb-cccc-dddd-eeee-0123456789ab\",\n" + "  \"timed_out\": true,\n"
+                + "  \"dtmf\": \"1234\",\n" + "  \"timestamp\": \"2020-01-01T14:00:00.000Z\"\n" + "}";
+
+        InputEvent inputEvent = InputEvent.fromJson(json);
+        assertEquals("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", inputEvent.getUuid());
+        assertEquals("bbbbbbbb-cccc-dddd-eeee-0123456789ab", inputEvent.getConversationUuid());
+        assertTrue(inputEvent.isTimedOut());
+        assertEquals("1234", inputEvent.getDtmf());
+
+        Calendar calendar = new GregorianCalendar(2020, Calendar.JANUARY, 1, 14, 0, 0);
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        assertEquals(calendar.getTime(), inputEvent.getTimestamp());
+    }
+}

--- a/src/test/java/com/nexmo/client/incoming/MessageEventTest.java
+++ b/src/test/java/com/nexmo/client/incoming/MessageEventTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class MessageEventTest {
+    @Test
+    public void testDeserializeIncomingMessage() {
+        String json = "{\n" + "  \"msisdn\": \"447700900001\",\n" + "  \"to\": \"447700900000\",\n"
+                + "  \"messageId\": \"0A0000000123ABCD1\",\n" + "  \"text\": \"Hello world\",\n"
+                + "  \"type\": \"text\",\n" + "  \"keyword\": \"Hello\",\n"
+                + "  \"message-timestamp\": \"2020-01-01T12:00:00.000+00:00\",\n" + "  \"timestamp\": \"1578787200\",\n"
+                + "  \"nonce\": \"aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n" + "  \"concat\": \"true\",\n"
+                + "  \"concat-ref\": \"1\",\n" + "  \"concat-total\": \"3\",\n" + "  \"concat-part\": \"2\",\n"
+                + "  \"data\": \"abc123\",\n" + "  \"udh\": \"abc123\"\n" + "}";
+
+        MessageEvent messageEvent = MessageEvent.fromJson(json);
+        assertEquals("447700900001", messageEvent.getMsisdn());
+        assertEquals("447700900000", messageEvent.getTo());
+        assertEquals("0A0000000123ABCD1", messageEvent.getMessageId());
+        assertEquals("Hello world", messageEvent.getText());
+        assertEquals("Hello", messageEvent.getKeyword());
+        assertEquals("1578787200", messageEvent.getTimestamp());
+        assertEquals("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", messageEvent.getNonce());
+        assertEquals(true, messageEvent.getConcat());
+        assertEquals(1, messageEvent.getConcatRef());
+        assertEquals(3, messageEvent.getConcatTotal());
+        assertEquals(2, messageEvent.getConcatPart());
+        assertEquals("abc123", messageEvent.getData());
+        assertEquals("abc123", messageEvent.getUdh());
+
+        Calendar calendar = new GregorianCalendar(2020, Calendar.JANUARY, 1, 12, 0, 0);
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        assertEquals(calendar.getTime(), messageEvent.getMessageTimestamp());
+    }
+}

--- a/src/test/java/com/nexmo/client/incoming/MessageTypeTest.java
+++ b/src/test/java/com/nexmo/client/incoming/MessageTypeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MessageTypeTest {
+    @Test
+    public void testMessageTypeFromString() {
+        assertEquals(MessageType.TEXT, MessageType.fromString("text"));
+    }
+
+    @Test
+    public void testDeserializeUnknownEnumsFallbackToUnknown() {
+        assertEquals(MessageType.UNKNOWN, MessageType.fromString("test"));
+    }
+}

--- a/src/test/java/com/nexmo/client/incoming/RecordEventTest.java
+++ b/src/test/java/com/nexmo/client/incoming/RecordEventTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.incoming;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class RecordEventTest {
+    @Test
+    public void testDeserializeRecordEvent() {
+        String json = "{\n" + "  \"start_time\": \"2020-01-01T12:00:00Z\",\n"
+                + "  \"recording_url\": \"https://api.nexmo.com/media/download?id=aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n"
+                + "  \"size\": 12345,\n" + "  \"recording_uuid\": \"aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n"
+                + "  \"end_time\": \"2020-01-01T12:01:00Z\",\n"
+                + "  \"conversation_uuid\": \"bbbbbbbb-cccc-dddd-eeee-0123456789ab\",\n"
+                + "  \"timestamp\": \"2020-01-01T14:00:00.000Z\"\n" + "}";
+
+        RecordEvent recordEvent = RecordEvent.fromJson(json);
+        assertEquals("https://api.nexmo.com/media/download?id=aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
+                recordEvent.getUrl()
+        );
+        assertEquals(12345, recordEvent.getSize());
+        assertEquals("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", recordEvent.getUuid());
+        assertEquals("bbbbbbbb-cccc-dddd-eeee-0123456789ab", recordEvent.getConversationUuid());
+
+        Calendar startTime = new GregorianCalendar(2020, Calendar.JANUARY, 1, 12, 0, 0);
+        startTime.setTimeZone(TimeZone.getTimeZone("UTC"));
+        assertEquals(startTime.getTime(), recordEvent.getStartTime());
+
+        Calendar endTime = new GregorianCalendar(2020, Calendar.JANUARY, 1, 12, 1, 0);
+        endTime.setTimeZone(TimeZone.getTimeZone("UTC"));
+        assertEquals(endTime.getTime(), recordEvent.getEndTime());
+
+        Calendar timestamp = new GregorianCalendar(2020, Calendar.JANUARY, 1, 14, 0, 0);
+        timestamp.setTimeZone(TimeZone.getTimeZone("UTC"));
+        assertEquals(timestamp.getTime(), recordEvent.getTimestamp());
+    }
+}


### PR DESCRIPTION
This change adds objects for deserializing the following events:
- `com.nexmo.client.incoming.MessageEvent` for incoming SMS.
- `com.nexmo.client.incoming.CallEvent` for information sent to the `event_url`.
- `com.nexmo.client.incoming.InputEvent` for dtmf input events.
- `com.nexmo.client.incoming.RecordEvent` for recording call information events.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
