### PR TITLE
Allow configuration of base uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Development]
 ### Added
 - Updated `VoiceName` enum with missing voices.
+- Added configuration object to be used with `HttpWrapper` to allow for customization.
+- Added the ability to customize the base URI used for the various endpoints.
 
 ## [3.8.0] - 2018-09-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,6 +73,43 @@ to your project's classpath.
 * Check the [Javadoc](http://nexmo.github.io/nexmo-java/) for full reference documentation.
 * There are also **many useful code samples** in our [nexmo-community/nexmo-java-quickstart](https://github.com/nexmo-community/nexmo-java-quickstart) repository.
 
+### Customize the Base URI
+By default, the client will use https://api.nexmo.com, https://rest.nexmo.com, and https://sns.nexmo.com as base URIs for the various endpoints. To customize these you can instantiate `NexmoClient` with an `HttpConfig` object.
+
+`HttpConfig.Builder` has been created to assist in building this object. Usage is as follows:
+
+```java
+HttpConfig httpConfig = new HttpConfig.Builder()
+        .apiBaseUri("https://api.example.com")
+        .restBaseUri("https://rest.example.com")
+        .snsBaseUri("https://sns.example.com")
+        .build();
+
+NexmoClient client = new NexmoClient(httpConfig, new TokenAuthMethod(API_KEY, API_SECRET));
+```
+
+If you do not specify a property, it will take on whatever the default value is. You can also set all three with a single method:
+
+```java
+HttpConfig httpConfig = new HttpConfig.Builder().baseUri("http://example.com").build();
+
+NexmoClient client = new NexmoClient(httpConfig, new TokenAuthMethod(API_KEY, API_SECRET));
+```
+
+To keep the default values, you can use `HttpConfig.defaultConfig()`:
+
+```java
+HttpConfig httpConfig = HttpConfig.defaultConfig();
+
+NexmoClient client = new NexmoClient(httpConfig, new TokenAuthMethod(API_KEY, API_SECRET));
+```
+
+You can also instantiate without the parameter:
+
+```java
+NexmoClient client = new NexmoClient(new TokenAuthMethod(API_KEY, API_SECRET));
+```
+
 ### Send an SMS
 
 Send an SMS with the Nexmo SMS API:

--- a/src/main/java/com/nexmo/client/BaseUriConfig.java
+++ b/src/main/java/com/nexmo/client/BaseUriConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client;
+
+public class BaseUriConfig {
+    private static final String DEFAULT_API_BASE_URI = "https://api.nexmo.com";
+    private static final String DEFAULT_REST_BASE_URI = "https://rest.nexmo.com";
+
+    private String apiBaseUri;
+    private String restBaseUri;
+
+    private BaseUriConfig(Builder builder) {
+        this.apiBaseUri = builder.apiBaseUri;
+        this.restBaseUri = builder.restBaseUri;
+    }
+
+    public String getApiBaseUri() {
+        return apiBaseUri;
+    }
+
+    public String getRestBaseUri() {
+        return restBaseUri;
+    }
+
+    public static class Builder {
+        private String apiBaseUri;
+        private String restBaseUri;
+
+        public Builder() {
+            this.apiBaseUri = DEFAULT_API_BASE_URI;
+            this.restBaseUri = DEFAULT_REST_BASE_URI;
+        }
+
+        public Builder apiBaseUri(String apiBaseUri) {
+            this.apiBaseUri = apiBaseUri;
+            return this;
+        }
+
+        public Builder restBaseUri(String restBaseUri) {
+            this.restBaseUri = restBaseUri;
+            return this;
+        }
+
+        public Builder bothUris(String bothUris) {
+            this.apiBaseUri = bothUris;
+            this.restBaseUri = bothUris;
+            return this;
+        }
+
+        public BaseUriConfig build() {
+            return new BaseUriConfig(this);
+        }
+    }
+}

--- a/src/main/java/com/nexmo/client/HttpConfig.java
+++ b/src/main/java/com/nexmo/client/HttpConfig.java
@@ -48,6 +48,34 @@ public class HttpConfig {
         return snsBaseUri;
     }
 
+    public boolean isDefaultApiBaseUri() {
+        return DEFAULT_API_BASE_URI.equals(apiBaseUri);
+    }
+
+    public boolean isDefaultRestBaseUri() {
+        return DEFAULT_REST_BASE_URI.equals(restBaseUri);
+    }
+
+    public boolean isDefaultSnsBaseUri() {
+        return DEFAULT_SNS_BASE_URI.equals(snsBaseUri);
+    }
+
+    public String getVersionedApiBaseUri(String version) {
+        return (isDefaultApiBaseUri()) ? appendVersionToUri(apiBaseUri, version) : apiBaseUri;
+    }
+
+    public String getVersionedRestBaseUri(String version) {
+        return (isDefaultRestBaseUri()) ? appendVersionToUri(restBaseUri, version) : restBaseUri;
+    }
+
+    public String getVersionedSnsBaseUri(String version) {
+        return (isDefaultSnsBaseUri()) ? appendVersionToUri(snsBaseUri, version) : snsBaseUri;
+    }
+
+    private String appendVersionToUri(String uri, String version) {
+        return uri + "/" + version;
+    }
+
     /**
      * @return an HttpConfig object with sensible defaults.
      */
@@ -72,7 +100,7 @@ public class HttpConfig {
          * @return The {@link Builder} to keep building.
          */
         public Builder apiBaseUri(String apiBaseUri) {
-            this.apiBaseUri = apiBaseUri;
+            this.apiBaseUri = sanitizeUri(apiBaseUri);
             return this;
         }
 
@@ -82,19 +110,7 @@ public class HttpConfig {
          * @return The {@link Builder} to keep building.
          */
         public Builder restBaseUri(String restBaseUri) {
-            this.restBaseUri = restBaseUri;
-            return this;
-        }
-
-        /**
-         * @param baseUri The base uri to use in place of {@link HttpConfig#DEFAULT_REST_BASE_URI}, {@link HttpConfig#DEFAULT_API_BASE_URI}, and {@link HttpConfig#DEFAULT_SNS_BASE_URI}
-         *
-         * @return The {@link Builder} to keep building.
-         */
-        public Builder baseUri(String baseUri) {
-            this.apiBaseUri = baseUri;
-            this.restBaseUri = baseUri;
-            this.snsBaseUri = baseUri;
+            this.restBaseUri = sanitizeUri(restBaseUri);
             return this;
         }
 
@@ -104,7 +120,20 @@ public class HttpConfig {
          * @return The {@link Builder} to keep building.
          */
         public Builder snsBaseUri(String snsBaseUri) {
-            this.snsBaseUri = snsBaseUri;
+            this.snsBaseUri = sanitizeUri(snsBaseUri);
+            return this;
+        }
+
+        /**
+         * @param baseUri The base uri to use in place of {@link HttpConfig#DEFAULT_REST_BASE_URI}, {@link HttpConfig#DEFAULT_API_BASE_URI}, and {@link HttpConfig#DEFAULT_SNS_BASE_URI}
+         *
+         * @return The {@link Builder} to keep building.
+         */
+        public Builder baseUri(String baseUri) {
+            String sanitizedUri = sanitizeUri(baseUri);
+            this.apiBaseUri = sanitizedUri;
+            this.restBaseUri = sanitizedUri;
+            this.snsBaseUri = sanitizedUri;
             return this;
         }
 
@@ -113,6 +142,14 @@ public class HttpConfig {
          */
         public HttpConfig build() {
             return new HttpConfig(this);
+        }
+
+        private String sanitizeUri(String uri) {
+            if (uri != null && uri.endsWith("/")) {
+                return uri.substring(0, uri.length() - 1);
+            }
+
+            return uri;
         }
     }
 }

--- a/src/main/java/com/nexmo/client/HttpConfig.java
+++ b/src/main/java/com/nexmo/client/HttpConfig.java
@@ -24,13 +24,16 @@ package com.nexmo.client;
 public class HttpConfig {
     private static final String DEFAULT_API_BASE_URI = "https://api.nexmo.com";
     private static final String DEFAULT_REST_BASE_URI = "https://rest.nexmo.com";
+    private static final String DEFAULT_SNS_BASE_URI = "https://sns.nexmo.com";
 
     private String apiBaseUri;
     private String restBaseUri;
+    private String snsBaseUri;
 
     private HttpConfig(Builder builder) {
         this.apiBaseUri = builder.apiBaseUri;
         this.restBaseUri = builder.restBaseUri;
+        this.snsBaseUri = builder.snsBaseUri;
     }
 
     public String getApiBaseUri() {
@@ -39,6 +42,10 @@ public class HttpConfig {
 
     public String getRestBaseUri() {
         return restBaseUri;
+    }
+
+    public String getSnsBaseUri() {
+        return snsBaseUri;
     }
 
     /**
@@ -51,10 +58,12 @@ public class HttpConfig {
     public static class Builder {
         private String apiBaseUri;
         private String restBaseUri;
+        private String snsBaseUri;
 
         public Builder() {
             this.apiBaseUri = DEFAULT_API_BASE_URI;
             this.restBaseUri = DEFAULT_REST_BASE_URI;
+            this.snsBaseUri = DEFAULT_SNS_BASE_URI;
         }
 
         /**
@@ -78,13 +87,24 @@ public class HttpConfig {
         }
 
         /**
-         * @param baseUri The base uri to use in place of {@link HttpConfig#DEFAULT_REST_BASE_URI} and {@link HttpConfig#DEFAULT_API_BASE_URI}
+         * @param baseUri The base uri to use in place of {@link HttpConfig#DEFAULT_REST_BASE_URI}, {@link HttpConfig#DEFAULT_API_BASE_URI}, and {@link HttpConfig#DEFAULT_SNS_BASE_URI}
          *
          * @return The {@link Builder} to keep building.
          */
         public Builder baseUri(String baseUri) {
             this.apiBaseUri = baseUri;
             this.restBaseUri = baseUri;
+            this.snsBaseUri = baseUri;
+            return this;
+        }
+
+        /**
+         * @param snsBaseUri The base uri to use in place of {@link HttpConfig#DEFAULT_SNS_BASE_URI}
+         *
+         * @return The {@link Builder} to keep building.
+         */
+        public Builder snsBaseUri(String snsBaseUri) {
+            this.snsBaseUri = snsBaseUri;
             return this;
         }
 

--- a/src/main/java/com/nexmo/client/HttpConfig.java
+++ b/src/main/java/com/nexmo/client/HttpConfig.java
@@ -21,14 +21,14 @@
  */
 package com.nexmo.client;
 
-public class BaseUriConfig {
+public class HttpConfig {
     private static final String DEFAULT_API_BASE_URI = "https://api.nexmo.com";
     private static final String DEFAULT_REST_BASE_URI = "https://rest.nexmo.com";
 
     private String apiBaseUri;
     private String restBaseUri;
 
-    private BaseUriConfig(Builder builder) {
+    private HttpConfig(Builder builder) {
         this.apiBaseUri = builder.apiBaseUri;
         this.restBaseUri = builder.restBaseUri;
     }
@@ -41,6 +41,13 @@ public class BaseUriConfig {
         return restBaseUri;
     }
 
+    /**
+     * @return an HttpConfig object with sensible defaults.
+     */
+    public static HttpConfig defaultConfig() {
+        return new Builder().build();
+    }
+
     public static class Builder {
         private String apiBaseUri;
         private String restBaseUri;
@@ -50,24 +57,42 @@ public class BaseUriConfig {
             this.restBaseUri = DEFAULT_REST_BASE_URI;
         }
 
+        /**
+         * @param apiBaseUri The base uri to use in place of {@link HttpConfig#DEFAULT_API_BASE_URI}
+         *
+         * @return The {@link Builder} to keep building.
+         */
         public Builder apiBaseUri(String apiBaseUri) {
             this.apiBaseUri = apiBaseUri;
             return this;
         }
 
+        /**
+         * @param restBaseUri The base uri to use in place of {@link HttpConfig#DEFAULT_REST_BASE_URI}
+         *
+         * @return The {@link Builder} to keep building.
+         */
         public Builder restBaseUri(String restBaseUri) {
             this.restBaseUri = restBaseUri;
             return this;
         }
 
-        public Builder bothUris(String bothUris) {
-            this.apiBaseUri = bothUris;
-            this.restBaseUri = bothUris;
+        /**
+         * @param baseUri The base uri to use in place of {@link HttpConfig#DEFAULT_REST_BASE_URI} and {@link HttpConfig#DEFAULT_API_BASE_URI}
+         *
+         * @return The {@link Builder} to keep building.
+         */
+        public Builder baseUri(String baseUri) {
+            this.apiBaseUri = baseUri;
+            this.restBaseUri = baseUri;
             return this;
         }
 
-        public BaseUriConfig build() {
-            return new BaseUriConfig(this);
+        /**
+         * @return A new {@link HttpConfig} object from the stored builder options.
+         */
+        public HttpConfig build() {
+            return new HttpConfig(this);
         }
     }
 }

--- a/src/main/java/com/nexmo/client/HttpWrapper.java
+++ b/src/main/java/com/nexmo/client/HttpWrapper.java
@@ -42,17 +42,28 @@ public class HttpWrapper {
 
     private AuthCollection authCollection;
     private HttpClient httpClient = null;
+    private BaseUriConfig baseUriConfig;
 
     public HttpWrapper(AuthCollection authCollection) {
+        this(new BaseUriConfig.Builder().build(), authCollection);
+    }
+
+    public HttpWrapper(BaseUriConfig baseUriConfig, AuthCollection authCollection) {
         this.authCollection = authCollection;
+        this.baseUriConfig = baseUriConfig;
     }
 
     public HttpWrapper(AuthMethod... authMethods) {
+        this(new BaseUriConfig.Builder().build(), authMethods);
+    }
+
+    public HttpWrapper(BaseUriConfig baseUriConfig, AuthMethod... authMethods) {
         this(new AuthCollection());
         for (AuthMethod authMethod : authMethods) {
             authCollection.add(authMethod);
         }
 
+        this.baseUriConfig = baseUriConfig;
     }
 
     public HttpClient getHttpClient() {
@@ -95,5 +106,9 @@ public class HttpWrapper {
                 .setUserAgent(String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION))
                 .setDefaultRequestConfig(requestConfig)
                 .build();
+    }
+
+    public BaseUriConfig getBaseUriConfig() {
+        return baseUriConfig;
     }
 }

--- a/src/main/java/com/nexmo/client/HttpWrapper.java
+++ b/src/main/java/com/nexmo/client/HttpWrapper.java
@@ -42,28 +42,28 @@ public class HttpWrapper {
 
     private AuthCollection authCollection;
     private HttpClient httpClient = null;
-    private BaseUriConfig baseUriConfig;
+    private HttpConfig httpConfig;
 
     public HttpWrapper(AuthCollection authCollection) {
-        this(new BaseUriConfig.Builder().build(), authCollection);
+        this(new HttpConfig.Builder().build(), authCollection);
     }
 
-    public HttpWrapper(BaseUriConfig baseUriConfig, AuthCollection authCollection) {
+    public HttpWrapper(HttpConfig httpConfig, AuthCollection authCollection) {
         this.authCollection = authCollection;
-        this.baseUriConfig = baseUriConfig;
+        this.httpConfig = httpConfig;
     }
 
     public HttpWrapper(AuthMethod... authMethods) {
-        this(new BaseUriConfig.Builder().build(), authMethods);
+        this(new HttpConfig.Builder().build(), authMethods);
     }
 
-    public HttpWrapper(BaseUriConfig baseUriConfig, AuthMethod... authMethods) {
+    public HttpWrapper(HttpConfig httpConfig, AuthMethod... authMethods) {
         this(new AuthCollection());
         for (AuthMethod authMethod : authMethods) {
             authCollection.add(authMethod);
         }
 
-        this.baseUriConfig = baseUriConfig;
+        this.httpConfig = httpConfig;
     }
 
     public HttpClient getHttpClient() {
@@ -108,7 +108,7 @@ public class HttpWrapper {
                 .build();
     }
 
-    public BaseUriConfig getBaseUriConfig() {
-        return baseUriConfig;
+    public HttpConfig getHttpConfig() {
+        return httpConfig;
     }
 }

--- a/src/main/java/com/nexmo/client/NexmoClient.java
+++ b/src/main/java/com/nexmo/client/NexmoClient.java
@@ -61,7 +61,11 @@ public class NexmoClient {
     private HttpWrapper httpWrapper;
 
     public NexmoClient(AuthMethod... authMethods) {
-        this.httpWrapper = new HttpWrapper(authMethods);
+        this(new HttpConfig.Builder().build(), authMethods);
+    }
+
+    public NexmoClient(HttpConfig httpConfig, AuthMethod... authMethods) {
+        this.httpWrapper = new HttpWrapper(httpConfig, authMethods);
 
         this.account = new AccountClient(this.httpWrapper);
         this.application = new ApplicationClient(this.httpWrapper);

--- a/src/main/java/com/nexmo/client/account/BalanceEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/BalanceEndpoint.java
@@ -36,9 +36,7 @@ public class BalanceEndpoint extends AbstractMethod<Void, BalanceResponse> {
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/account/get-balance";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/account/get-balance";
 
     public BalanceEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,7 +49,7 @@ public class BalanceEndpoint extends AbstractMethod<Void, BalanceResponse> {
 
     @Override
     public RequestBuilder makeRequest(Void request) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get(uri);
+        RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getBaseUriConfig().getRestBaseUri() + PATH);
         return requestBuilder;
     }
 

--- a/src/main/java/com/nexmo/client/account/BalanceEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/BalanceEndpoint.java
@@ -49,7 +49,7 @@ public class BalanceEndpoint extends AbstractMethod<Void, BalanceResponse> {
 
     @Override
     public RequestBuilder makeRequest(Void request) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getBaseUriConfig().getRestBaseUri() + PATH);
+        RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         return requestBuilder;
     }
 

--- a/src/main/java/com/nexmo/client/account/CreateSecretMethod.java
+++ b/src/main/java/com/nexmo/client/account/CreateSecretMethod.java
@@ -40,9 +40,7 @@ import java.io.UnsupportedEncodingException;
 public class CreateSecretMethod extends AbstractMethod<CreateSecretRequest, SecretResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/accounts/%s/secrets";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/accounts/%s/secrets";
 
     CreateSecretMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -63,7 +61,7 @@ public class CreateSecretMethod extends AbstractMethod<CreateSecretRequest, Secr
             throw new IllegalArgumentException("Secret is required.");
         }
 
-        String uri = String.format(this.uri, createSecretRequest.getApiKey());
+        String uri = String.format(httpWrapper.getHttpConfig().getApiBaseUri() + PATH, createSecretRequest.getApiKey());
         return RequestBuilder
                 .post(uri)
                 .setEntity(new StringEntity(createSecretRequest.toJson(), ContentType.APPLICATION_JSON));

--- a/src/main/java/com/nexmo/client/account/GetSecretMethod.java
+++ b/src/main/java/com/nexmo/client/account/GetSecretMethod.java
@@ -38,9 +38,7 @@ import java.io.UnsupportedEncodingException;
 public class GetSecretMethod extends AbstractMethod<SecretRequest, SecretResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/accounts/%s/secrets/%s";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/accounts/%s/secrets/%s";
 
     GetSecretMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -61,7 +59,11 @@ public class GetSecretMethod extends AbstractMethod<SecretRequest, SecretRespons
             throw new IllegalArgumentException("Secret id is required.");
         }
 
-        String uri = String.format(this.uri, secretRequest.getApiKey(), secretRequest.getSecretId());
+        String uri = String.format(
+                httpWrapper.getHttpConfig().getApiBaseUri() + PATH,
+                secretRequest.getApiKey(),
+                secretRequest.getSecretId()
+        );
         return RequestBuilder.get(uri);
     }
 

--- a/src/main/java/com/nexmo/client/account/ListSecretsMethod.java
+++ b/src/main/java/com/nexmo/client/account/ListSecretsMethod.java
@@ -38,9 +38,7 @@ import java.io.UnsupportedEncodingException;
 public class ListSecretsMethod extends AbstractMethod<String, ListSecretsResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/accounts/%s/secrets";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/accounts/%s/secrets";
 
     ListSecretsMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -57,7 +55,7 @@ public class ListSecretsMethod extends AbstractMethod<String, ListSecretsRespons
             throw new IllegalArgumentException("API key is required.");
         }
 
-        String uri = String.format(this.uri, apiKey);
+        String uri = String.format(httpWrapper.getHttpConfig().getApiBaseUri() + PATH, apiKey);
         return RequestBuilder.get(uri);
     }
 

--- a/src/main/java/com/nexmo/client/account/PrefixPricingMethod.java
+++ b/src/main/java/com/nexmo/client/account/PrefixPricingMethod.java
@@ -33,9 +33,7 @@ import java.io.IOException;
 public class PrefixPricingMethod extends AbstractMethod<PrefixPricingRequest, PrefixPricingResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_BASE_URI = "https://rest.nexmo.com/account/get-prefix-pricing/outbound/";
-
-    private String baseUri = DEFAULT_BASE_URI;
+    private static final String PATH = "/get-prefix-pricing/outbound/";
 
     PrefixPricingMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -48,7 +46,10 @@ public class PrefixPricingMethod extends AbstractMethod<PrefixPricingRequest, Pr
 
     @Override
     public RequestBuilder makeRequest(PrefixPricingRequest prefixPricingRequest) {
-        String uri = this.baseUri + prefixPricingRequest.getServiceType().name().toLowerCase();
+        String uri = httpWrapper.getHttpConfig().getRestBaseUri() + PATH + prefixPricingRequest
+                .getServiceType()
+                .name()
+                .toLowerCase();
         return RequestBuilder.get(uri).addParameter("prefix", prefixPricingRequest.getPrefix());
     }
 

--- a/src/main/java/com/nexmo/client/account/RevokeSecretMethod.java
+++ b/src/main/java/com/nexmo/client/account/RevokeSecretMethod.java
@@ -37,9 +37,7 @@ import java.io.UnsupportedEncodingException;
 public class RevokeSecretMethod extends AbstractMethod<SecretRequest, Void> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/accounts/%s/secrets/%s";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/accounts/%s/secrets/%s";
 
     RevokeSecretMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -60,7 +58,11 @@ public class RevokeSecretMethod extends AbstractMethod<SecretRequest, Void> {
             throw new IllegalArgumentException("Secret id is required.");
         }
 
-        String uri = String.format(this.uri, secretRequest.getApiKey(), secretRequest.getSecretId());
+        String uri = String.format(
+                httpWrapper.getHttpConfig().getApiBaseUri() + PATH,
+                secretRequest.getApiKey(),
+                secretRequest.getSecretId()
+        );
         return RequestBuilder.delete(uri);
     }
 

--- a/src/main/java/com/nexmo/client/account/SmsPricingMethod.java
+++ b/src/main/java/com/nexmo/client/account/SmsPricingMethod.java
@@ -24,9 +24,7 @@ package com.nexmo.client.account;
 import com.nexmo.client.HttpWrapper;
 
 public class SmsPricingMethod extends PricingMethod {
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/account/get-pricing/outbound/sms";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/account/get-pricing/outbound/sms";
 
     SmsPricingMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -34,6 +32,6 @@ public class SmsPricingMethod extends PricingMethod {
 
     @Override
     String getUri() {
-        return this.uri;
+        return httpWrapper.getHttpConfig().getRestBaseUri() + PATH;
     }
 }

--- a/src/main/java/com/nexmo/client/account/TopUpMethod.java
+++ b/src/main/java/com/nexmo/client/account/TopUpMethod.java
@@ -36,9 +36,7 @@ import java.io.UnsupportedEncodingException;
 public class TopUpMethod extends AbstractMethod<TopUpRequest, Void> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/account/top-up";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/account/top-up";
 
     public TopUpMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,7 +49,9 @@ public class TopUpMethod extends AbstractMethod<TopUpRequest, Void> {
 
     @Override
     public RequestBuilder makeRequest(TopUpRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        return RequestBuilder.get(this.uri).addParameter("trx", request.getTrx());
+        return RequestBuilder
+                .get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH)
+                .addParameter("trx", request.getTrx());
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/account/VoicePricingMethod.java
+++ b/src/main/java/com/nexmo/client/account/VoicePricingMethod.java
@@ -24,9 +24,7 @@ package com.nexmo.client.account;
 import com.nexmo.client.HttpWrapper;
 
 public class VoicePricingMethod extends PricingMethod {
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/account/get-pricing/outbound/voice";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/account/get-pricing/outbound/voice";
 
     VoicePricingMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -34,6 +32,6 @@ public class VoicePricingMethod extends PricingMethod {
 
     @Override
     String getUri() {
-        return this.uri;
+        return httpWrapper.getHttpConfig().getRestBaseUri() + PATH;
     }
 }

--- a/src/main/java/com/nexmo/client/applications/endpoints/CreateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/CreateApplicationMethod.java
@@ -38,9 +38,7 @@ public class CreateApplicationMethod extends AbstractMethod<CreateApplicationReq
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/applications";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/v1/applications";
 
     public CreateApplicationMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -54,7 +52,7 @@ public class CreateApplicationMethod extends AbstractMethod<CreateApplicationReq
     @Override
     public RequestBuilder makeRequest(CreateApplicationRequest request) throws NexmoClientException,
                                                                                UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.post(uri);
+        RequestBuilder requestBuilder = RequestBuilder.post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/applications/endpoints/CreateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/CreateApplicationMethod.java
@@ -38,7 +38,7 @@ public class CreateApplicationMethod extends AbstractMethod<CreateApplicationReq
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String PATH = "/v1/applications";
+    private static final String PATH = "/applications";
 
     public CreateApplicationMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -52,7 +52,7 @@ public class CreateApplicationMethod extends AbstractMethod<CreateApplicationReq
     @Override
     public RequestBuilder makeRequest(CreateApplicationRequest request) throws NexmoClientException,
                                                                                UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH);
+        RequestBuilder requestBuilder = RequestBuilder.post(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethod.java
@@ -36,9 +36,7 @@ public class DeleteApplicationMethod extends AbstractMethod<String, Void> {
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/applications";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/v1/applications";
 
     public DeleteApplicationMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -50,9 +48,9 @@ public class DeleteApplicationMethod extends AbstractMethod<String, Void> {
     }
 
     @Override
-    public RequestBuilder makeRequest(String applicationId) throws NexmoClientException,
-                                                                   UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.delete(uri + "/" + applicationId);
+    public RequestBuilder makeRequest(String applicationId) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder.delete(
+                httpWrapper.getHttpConfig().getApiBaseUri() + PATH + "/" + applicationId);
         return requestBuilder;
     }
 

--- a/src/main/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethod.java
@@ -36,7 +36,7 @@ public class DeleteApplicationMethod extends AbstractMethod<String, Void> {
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String PATH = "/v1/applications";
+    private static final String PATH = "/applications/";
 
     public DeleteApplicationMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -50,7 +50,7 @@ public class DeleteApplicationMethod extends AbstractMethod<String, Void> {
     @Override
     public RequestBuilder makeRequest(String applicationId) throws NexmoClientException, UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder.delete(
-                httpWrapper.getHttpConfig().getApiBaseUri() + PATH + "/" + applicationId);
+                httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + applicationId);
         return requestBuilder;
     }
 

--- a/src/main/java/com/nexmo/client/applications/endpoints/GetApplicationEndpoint.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/GetApplicationEndpoint.java
@@ -37,9 +37,7 @@ public class GetApplicationEndpoint extends AbstractMethod<String, ApplicationDe
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/applications";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/v1/applications";
 
     public GetApplicationEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,9 +49,9 @@ public class GetApplicationEndpoint extends AbstractMethod<String, ApplicationDe
     }
 
     @Override
-    public RequestBuilder makeRequest(String applicationId) throws NexmoClientException,
-                                                                   UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get(uri + "/" + applicationId);
+    public RequestBuilder makeRequest(String applicationId) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder.get(
+                httpWrapper.getHttpConfig().getApiBaseUri() + PATH + "/" + applicationId);
         return requestBuilder;
     }
 

--- a/src/main/java/com/nexmo/client/applications/endpoints/GetApplicationEndpoint.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/GetApplicationEndpoint.java
@@ -37,7 +37,7 @@ public class GetApplicationEndpoint extends AbstractMethod<String, ApplicationDe
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String PATH = "/v1/applications";
+    private static final String PATH = "/applications/";
 
     public GetApplicationEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,7 +51,7 @@ public class GetApplicationEndpoint extends AbstractMethod<String, ApplicationDe
     @Override
     public RequestBuilder makeRequest(String applicationId) throws NexmoClientException, UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder.get(
-                httpWrapper.getHttpConfig().getApiBaseUri() + PATH + "/" + applicationId);
+                httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + applicationId);
         return requestBuilder;
     }
 

--- a/src/main/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpoint.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpoint.java
@@ -38,9 +38,7 @@ public class ListApplicationsEndpoint extends AbstractMethod<ListApplicationsReq
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/applications";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/v1/applications";
 
     public ListApplicationsEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -52,9 +50,8 @@ public class ListApplicationsEndpoint extends AbstractMethod<ListApplicationsReq
     }
 
     @Override
-    public RequestBuilder makeRequest(ListApplicationsRequest request) throws NexmoClientException,
-                                                                              UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get(uri);
+    public RequestBuilder makeRequest(ListApplicationsRequest request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getHttpConfig().getApiBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpoint.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpoint.java
@@ -38,7 +38,7 @@ public class ListApplicationsEndpoint extends AbstractMethod<ListApplicationsReq
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String PATH = "/v1/applications";
+    private static final String PATH = "/applications";
 
     public ListApplicationsEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,7 +51,8 @@ public class ListApplicationsEndpoint extends AbstractMethod<ListApplicationsReq
 
     @Override
     public RequestBuilder makeRequest(ListApplicationsRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getHttpConfig().getApiBaseUri() + PATH);
+        RequestBuilder requestBuilder = RequestBuilder.get(
+                httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethod.java
@@ -38,9 +38,7 @@ public class UpdateApplicationMethod extends AbstractMethod<UpdateApplicationReq
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/applications";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/v1/applications";
 
     public UpdateApplicationMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -52,9 +50,9 @@ public class UpdateApplicationMethod extends AbstractMethod<UpdateApplicationReq
     }
 
     @Override
-    public RequestBuilder makeRequest(UpdateApplicationRequest request) throws NexmoClientException,
-                                                                               UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.put(uri + "/" + request.getApplicationId());
+    public RequestBuilder makeRequest(UpdateApplicationRequest request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder.put(
+                httpWrapper.getHttpConfig().getApiBaseUri() + PATH + "/" + request.getApplicationId());
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethod.java
@@ -38,7 +38,7 @@ public class UpdateApplicationMethod extends AbstractMethod<UpdateApplicationReq
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String PATH = "/v1/applications";
+    private static final String PATH = "/applications/";
 
     public UpdateApplicationMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -52,7 +52,7 @@ public class UpdateApplicationMethod extends AbstractMethod<UpdateApplicationReq
     @Override
     public RequestBuilder makeRequest(UpdateApplicationRequest request) throws NexmoClientException, UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder.put(
-                httpWrapper.getHttpConfig().getApiBaseUri() + PATH + "/" + request.getApplicationId());
+                httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + request.getApplicationId());
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/conversion/ConversionMethod.java
+++ b/src/main/java/com/nexmo/client/conversion/ConversionMethod.java
@@ -39,9 +39,7 @@ class ConversionMethod extends AbstractMethod<ConversionRequest, Void> {
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_BASE_URI = "https://api.nexmo.com/conversions/";
-
-    private String baseUri = DEFAULT_BASE_URI;
+    private static final String PATH = "/conversions/";
 
     ConversionMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -54,12 +52,16 @@ class ConversionMethod extends AbstractMethod<ConversionRequest, Void> {
 
     @Override
     public RequestBuilder makeRequest(ConversionRequest conversionRequest) throws NexmoClientException, UnsupportedEncodingException {
-        String uri = this.baseUri + conversionRequest.getType().name().toLowerCase();
-        return RequestBuilder.post(uri)
+        String uri =
+                httpWrapper.getHttpConfig().getApiBaseUri() + PATH + conversionRequest.getType().name().toLowerCase();
+        return RequestBuilder
+                .post(uri)
                 .addParameter("message-id", conversionRequest.getMessageId())
                 .addParameter("delivered", String.valueOf(conversionRequest.isDelivered()))
-                .addParameter("timestamp",
-                              new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(conversionRequest.getTimestamp()));
+                .addParameter(
+                        "timestamp",
+                        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(conversionRequest.getTimestamp())
+                );
     }
 
     @Override
@@ -72,6 +74,6 @@ class ConversionMethod extends AbstractMethod<ConversionRequest, Void> {
     }
 
     public String getBaseUri() {
-        return this.baseUri;
+        return httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
     }
 }

--- a/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightEndpoint.java
+++ b/src/main/java/com/nexmo/client/insight/advanced/AdvancedInsightEndpoint.java
@@ -36,9 +36,7 @@ import java.io.UnsupportedEncodingException;
 public class AdvancedInsightEndpoint extends AbstractMethod<AdvancedInsightRequest, AdvancedInsightResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/ni/advanced/json";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/ni/advanced/json";
 
     public AdvancedInsightEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,7 +49,8 @@ public class AdvancedInsightEndpoint extends AbstractMethod<AdvancedInsightReque
 
     @Override
     public RequestBuilder makeRequest(AdvancedInsightRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.post(uri)
+        RequestBuilder requestBuilder = RequestBuilder
+                .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
                 .addParameter("number", request.getNumber());
         if (request.getCountry() != null) {
             requestBuilder.addParameter("country", request.getCountry());

--- a/src/main/java/com/nexmo/client/insight/basic/BasicInsightEndpoint.java
+++ b/src/main/java/com/nexmo/client/insight/basic/BasicInsightEndpoint.java
@@ -37,7 +37,7 @@ public class BasicInsightEndpoint extends AbstractMethod<BasicInsightRequest, Ba
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String PATH = "https://api.nexmo.com/ni/basic/json";
+    private static final String PATH = "/ni/basic/json";
 
     public BasicInsightEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);

--- a/src/main/java/com/nexmo/client/insight/basic/BasicInsightEndpoint.java
+++ b/src/main/java/com/nexmo/client/insight/basic/BasicInsightEndpoint.java
@@ -37,9 +37,7 @@ public class BasicInsightEndpoint extends AbstractMethod<BasicInsightRequest, Ba
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/ni/basic/json";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "https://api.nexmo.com/ni/basic/json";
 
     public BasicInsightEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -52,7 +50,8 @@ public class BasicInsightEndpoint extends AbstractMethod<BasicInsightRequest, Ba
 
     @Override
     public RequestBuilder makeRequest(BasicInsightRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.post(uri)
+        RequestBuilder requestBuilder = RequestBuilder
+                .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
                 .addParameter("number", request.getNumber());
         if (request.getCountry() != null) {
             requestBuilder.addParameter("country", request.getCountry());

--- a/src/main/java/com/nexmo/client/insight/standard/StandardInsightEndpoint.java
+++ b/src/main/java/com/nexmo/client/insight/standard/StandardInsightEndpoint.java
@@ -36,9 +36,7 @@ import java.io.UnsupportedEncodingException;
 public class StandardInsightEndpoint extends AbstractMethod<StandardInsightRequest, StandardInsightResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/ni/standard/json";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/ni/standard/json";
 
     public StandardInsightEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -50,9 +48,9 @@ public class StandardInsightEndpoint extends AbstractMethod<StandardInsightReque
     }
 
     @Override
-    public RequestBuilder makeRequest(StandardInsightRequest request) throws NexmoClientException,
-                                                                             UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.post(uri)
+    public RequestBuilder makeRequest(StandardInsightRequest request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder
+                .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
                 .addParameter("number", request.getNumber());
         if (request.getCountry() != null) {
             requestBuilder.addParameter("country", request.getCountry());

--- a/src/main/java/com/nexmo/client/numbers/BuyNumberEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/BuyNumberEndpoint.java
@@ -36,9 +36,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 public class BuyNumberEndpoint extends AbstractMethod<BuyNumberRequest, BuyNumberResponse> {
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/number/buy";
+    private static final String PATH = "/number/buy";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
-    private String uri = DEFAULT_URI;
 
     public BuyNumberEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,7 +50,9 @@ public class BuyNumberEndpoint extends AbstractMethod<BuyNumberRequest, BuyNumbe
 
     @Override
     public RequestBuilder makeRequest(BuyNumberRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.post().setUri(uri);
+        RequestBuilder requestBuilder = RequestBuilder
+                .post()
+                .setUri(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/numbers/CancelNumberEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/CancelNumberEndpoint.java
@@ -37,9 +37,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 public class CancelNumberEndpoint extends AbstractMethod<CancelNumberRequest, CancelNumberResponse> {
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/number/cancel";
+    private static final String PATH = "/number/cancel";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
-    private String uri = DEFAULT_URI;
 
     public CancelNumberEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,9 +50,10 @@ public class CancelNumberEndpoint extends AbstractMethod<CancelNumberRequest, Ca
     }
 
     @Override
-    public RequestBuilder makeRequest(CancelNumberRequest request) throws NexmoClientException,
-                                                                          UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.post().setUri(uri);
+    public RequestBuilder makeRequest(CancelNumberRequest request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder
+                .post()
+                .setUri(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/numbers/ListNumbersEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/ListNumbersEndpoint.java
@@ -34,9 +34,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 public class ListNumbersEndpoint extends AbstractMethod<ListNumbersFilter, ListNumbersResponse> {
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/account/numbers";
+    private static final String PATH = "/account/numbers";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
-    private String uri = DEFAULT_URI;
 
     public ListNumbersEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -48,9 +47,10 @@ public class ListNumbersEndpoint extends AbstractMethod<ListNumbersFilter, ListN
     }
 
     @Override
-    public RequestBuilder makeRequest(ListNumbersFilter request) throws NexmoClientException,
-                                                                        UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get().setUri(uri);
+    public RequestBuilder makeRequest(ListNumbersFilter request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder
+                .get()
+                .setUri(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/numbers/SearchNumbersEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/SearchNumbersEndpoint.java
@@ -39,9 +39,8 @@ import java.io.UnsupportedEncodingException;
  * Use {@link NumbersClient#searchNumbers} instead of this class directly.
  */
 public class SearchNumbersEndpoint extends AbstractMethod<SearchNumbersFilter, SearchNumbersResponse> {
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/number/search";
+    private static final String PATH = "/number/search";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
-    private String uri = DEFAULT_URI;
 
     public SearchNumbersEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -53,9 +52,10 @@ public class SearchNumbersEndpoint extends AbstractMethod<SearchNumbersFilter, S
     }
 
     @Override
-    public RequestBuilder makeRequest(SearchNumbersFilter request) throws NexmoClientException,
-                                                                          UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get().setUri(uri);
+    public RequestBuilder makeRequest(SearchNumbersFilter request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder
+                .get()
+                .setUri(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/numbers/UpdateNumberEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/UpdateNumberEndpoint.java
@@ -37,9 +37,7 @@ public class UpdateNumberEndpoint extends AbstractMethod<UpdateNumberRequest, Vo
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/number/update";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/number/update";
 
     public UpdateNumberEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,17 +49,16 @@ public class UpdateNumberEndpoint extends AbstractMethod<UpdateNumberRequest, Vo
     }
 
     @Override
-    public RequestBuilder makeRequest(UpdateNumberRequest request) throws NexmoClientException,
-                                                                          UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.post(uri);
+    public RequestBuilder makeRequest(UpdateNumberRequest request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder.post(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }
 
     @Override
     public Void parseResponse(HttpResponse httpResponse) throws IOException, NexmoClientException {
-        UpdateNumberResponse response = UpdateNumberResponse.fromJson(new BasicResponseHandler().handleResponse
-                (httpResponse));
+        UpdateNumberResponse response = UpdateNumberResponse.fromJson(new BasicResponseHandler().handleResponse(
+                httpResponse));
         if (!response.getErrorCode().equals("200")) {
             throw new NexmoMethodFailedException(response.getErrorCodeLabel());
         }

--- a/src/main/java/com/nexmo/client/redact/RedactMethod.java
+++ b/src/main/java/com/nexmo/client/redact/RedactMethod.java
@@ -39,7 +39,7 @@ import java.io.UnsupportedEncodingException;
 public class RedactMethod extends AbstractMethod<RedactRequest, RedactResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String PATH = "/v1/redact/transaction";
+    private static final String PATH = "/redact/transaction";
 
     RedactMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -61,7 +61,7 @@ public class RedactMethod extends AbstractMethod<RedactRequest, RedactResponse> 
         }
 
         return RequestBuilder
-                .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
+                .post(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH)
                 .setEntity(new StringEntity(redactRequest.toJson(), ContentType.APPLICATION_JSON));
     }
 

--- a/src/main/java/com/nexmo/client/redact/RedactMethod.java
+++ b/src/main/java/com/nexmo/client/redact/RedactMethod.java
@@ -39,9 +39,7 @@ import java.io.UnsupportedEncodingException;
 public class RedactMethod extends AbstractMethod<RedactRequest, RedactResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/redact/transaction";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/v1/redact/transaction";
 
     RedactMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -62,7 +60,8 @@ public class RedactMethod extends AbstractMethod<RedactRequest, RedactResponse> 
             throw new IllegalArgumentException("Redacting SMS requires a type.");
         }
 
-        return RequestBuilder.post(this.uri)
+        return RequestBuilder
+                .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
                 .setEntity(new StringEntity(redactRequest.toJson(), ContentType.APPLICATION_JSON));
     }
 

--- a/src/main/java/com/nexmo/client/sms/SearchRejectedMessagesEndpoint.java
+++ b/src/main/java/com/nexmo/client/sms/SearchRejectedMessagesEndpoint.java
@@ -36,9 +36,7 @@ public class SearchRejectedMessagesEndpoint extends AbstractMethod<SearchRejecte
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/search/rejections";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/search/rejections";
 
     public SearchRejectedMessagesEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -50,9 +48,8 @@ public class SearchRejectedMessagesEndpoint extends AbstractMethod<SearchRejecte
     }
 
     @Override
-    public RequestBuilder makeRequest(SearchRejectedMessagesRequest request) throws NexmoClientException,
-                                                                                    UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get(uri);
+    public RequestBuilder makeRequest(SearchRejectedMessagesRequest request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/sms/SmsSearchEndpoint.java
+++ b/src/main/java/com/nexmo/client/sms/SmsSearchEndpoint.java
@@ -36,9 +36,7 @@ public class SmsSearchEndpoint extends AbstractMethod<SearchSmsRequest, SearchSm
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/search/messages";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/search/messages";
 
     public SmsSearchEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -50,9 +48,8 @@ public class SmsSearchEndpoint extends AbstractMethod<SearchSmsRequest, SearchSm
     }
 
     @Override
-    public RequestBuilder makeRequest(SearchSmsRequest request) throws NexmoClientException,
-                                                                       UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get(uri);
+    public RequestBuilder makeRequest(SearchSmsRequest request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/sms/SmsSingleSearchEndpoint.java
+++ b/src/main/java/com/nexmo/client/sms/SmsSingleSearchEndpoint.java
@@ -36,9 +36,7 @@ public class SmsSingleSearchEndpoint extends AbstractMethod<String, SmsSingleSea
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://rest.nexmo.com/search/message";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/search/message";
 
     public SmsSingleSearchEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,7 +49,7 @@ public class SmsSingleSearchEndpoint extends AbstractMethod<String, SmsSingleSea
 
     @Override
     public RequestBuilder makeRequest(String id) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.get(uri);
+        RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         requestBuilder.addParameter("id", id);
         return requestBuilder;
     }

--- a/src/main/java/com/nexmo/client/sns/SnsEndpoint.java
+++ b/src/main/java/com/nexmo/client/sns/SnsEndpoint.java
@@ -27,12 +27,12 @@ import com.nexmo.client.NexmoResponseParseException;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
 import com.nexmo.client.legacyutils.XmlParser;
+import com.nexmo.client.legacyutils.XmlUtil;
 import com.nexmo.client.sns.request.SnsRequest;
 import com.nexmo.client.sns.response.SnsPublishResponse;
 import com.nexmo.client.sns.response.SnsResponse;
 import com.nexmo.client.sns.response.SnsSubscribeResponse;
 import com.nexmo.client.voice.endpoints.AbstractMethod;
-import com.nexmo.client.legacyutils.XmlUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
@@ -51,9 +51,7 @@ public class SnsEndpoint extends AbstractMethod<SnsRequest, SnsResponse> {
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_BASE_URL = "https://sns.nexmo.com/sns/xml";
-
-    private String uri = DEFAULT_BASE_URL;
+    private static final String PATH = "/sns/xml";
 
     private XmlParser xmlParser = new XmlParser();
 
@@ -69,7 +67,7 @@ public class SnsEndpoint extends AbstractMethod<SnsRequest, SnsResponse> {
     @Override
     public RequestBuilder makeRequest(SnsRequest snsRequest) throws NexmoClientException, UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder
-                .post(this.uri)
+                .post(httpWrapper.getHttpConfig().getSnsBaseUri() + PATH)
                 .addParameter("cmd", snsRequest.getCommand());
         for (Map.Entry<String, String> entry : snsRequest.getQueryParameters().entrySet()) {
             requestBuilder.addParameter(entry.getKey(), entry.getValue());
@@ -120,8 +118,8 @@ public class SnsEndpoint extends AbstractMethod<SnsRequest, SnsResponse> {
                     try {
                         resultCode = XmlUtil.intValue(node);
                     } catch (Exception e) {
-                        log.error("xml parser .. invalid value in <resultCode> node [ " + XmlUtil.stringValue(node) +
-                                " ] ");
+                        log.error("xml parser .. invalid value in <resultCode> node [ " + XmlUtil.stringValue(node)
+                                + " ] ");
                         resultCode = SnsResponse.STATUS_INTERNAL_ERROR;
                     }
                 } else if (node.getNodeName().equals("resultMessage")) {
@@ -130,8 +128,7 @@ public class SnsEndpoint extends AbstractMethod<SnsRequest, SnsResponse> {
                     transactionId = XmlUtil.stringValue(node);
                 } else if (node.getNodeName().equals("subscriberArn")) {
                     subscriberArn = XmlUtil.stringValue(node);
-                } else
-                    log.error("xml parser .. unknown node found in nexmo-sns [ " + node.getNodeName() + " ] ");
+                } else log.error("xml parser .. unknown node found in nexmo-sns [ " + node.getNodeName() + " ] ");
             }
         }
 

--- a/src/main/java/com/nexmo/client/verify/CheckMethod.java
+++ b/src/main/java/com/nexmo/client/verify/CheckMethod.java
@@ -36,9 +36,7 @@ import java.io.UnsupportedEncodingException;
 public class CheckMethod extends AbstractMethod<CheckRequest, CheckResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/verify/check/json";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/verify/check/json";
 
     CheckMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -54,7 +52,7 @@ public class CheckMethod extends AbstractMethod<CheckRequest, CheckResponse> {
         if (request.getRequestId() == null || request.getCode() == null)
             throw new IllegalArgumentException("request ID and code parameters are mandatory.");
 
-        RequestBuilder result = RequestBuilder.post(this.uri).addParameter("request_id", request.getRequestId())
+        RequestBuilder result = RequestBuilder.post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH).addParameter("request_id", request.getRequestId())
 
                 .addParameter("code", request.getCode());
         if (request.getIpAddress() != null) result.addParameter("ip_address", request.getIpAddress());

--- a/src/main/java/com/nexmo/client/verify/SearchMethod.java
+++ b/src/main/java/com/nexmo/client/verify/SearchMethod.java
@@ -36,9 +36,7 @@ import java.io.UnsupportedEncodingException;
 public class SearchMethod extends AbstractMethod<SearchRequest, SearchVerifyResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/verify/search/json";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/verify/search/json";
 
     SearchMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -51,7 +49,7 @@ public class SearchMethod extends AbstractMethod<SearchRequest, SearchVerifyResp
 
     @Override
     public RequestBuilder makeRequest(SearchRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder result = RequestBuilder.post(this.uri);
+        RequestBuilder result = RequestBuilder.post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH);
         if (request.getRequestIds().length == 1) {
             result.addParameter("request_id", request.getRequestIds()[0]);
         } else {

--- a/src/main/java/com/nexmo/client/verify/VerifyMethod.java
+++ b/src/main/java/com/nexmo/client/verify/VerifyMethod.java
@@ -37,9 +37,7 @@ import java.io.UnsupportedEncodingException;
 class VerifyMethod extends AbstractMethod<VerifyRequest, VerifyResponse> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/verify/json";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/verify/json";
 
     VerifyMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -52,7 +50,8 @@ class VerifyMethod extends AbstractMethod<VerifyRequest, VerifyResponse> {
 
     @Override
     public RequestBuilder makeRequest(VerifyRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder result = RequestBuilder.post(this.uri)
+        RequestBuilder result = RequestBuilder
+                .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
                 .addParameter("number", request.getNumber())
                 .addParameter("brand", request.getBrand());
 
@@ -66,7 +65,8 @@ class VerifyMethod extends AbstractMethod<VerifyRequest, VerifyResponse> {
 
         if (request.getLocale() != null) {
             result.addParameter(new BasicNameValuePair("lg",
-                    (request.getLocale().getLanguage() + "-" + request.getLocale().getCountry()).toLowerCase()));
+                    (request.getLocale().getLanguage() + "-" + request.getLocale().getCountry()).toLowerCase()
+            ));
         }
 
         if (request.getType() != null) {

--- a/src/main/java/com/nexmo/client/verify/endpoints/ControlEndpoint.java
+++ b/src/main/java/com/nexmo/client/verify/endpoints/ControlEndpoint.java
@@ -40,9 +40,7 @@ public class ControlEndpoint extends AbstractMethod<ControlRequest, ControlRespo
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/verify/control/json";
-
-    private String uri = DEFAULT_URI;
+    private static final String PATH = "/verify/control/json";
 
     public ControlEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -54,21 +52,17 @@ public class ControlEndpoint extends AbstractMethod<ControlRequest, ControlRespo
     }
 
     @Override
-    public RequestBuilder makeRequest(ControlRequest request) throws NexmoClientException,
-                                                                     UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.post(uri);
+    public RequestBuilder makeRequest(ControlRequest request) throws NexmoClientException, UnsupportedEncodingException {
+        RequestBuilder requestBuilder = RequestBuilder.post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;
     }
 
     @Override
     public ControlResponse parseResponse(HttpResponse response) throws IOException, NexmoClientException {
-        ControlResponse controlResponse = ControlResponse.fromJson(
-                new BasicResponseHandler().handleResponse(response));
+        ControlResponse controlResponse = ControlResponse.fromJson(new BasicResponseHandler().handleResponse(response));
         if (!controlResponse.getStatus().equals("0")) {
-            throw new VerifyException(
-                    controlResponse.getStatus(),
-                    controlResponse.getErrorText());
+            throw new VerifyException(controlResponse.getStatus(), controlResponse.getErrorText());
         }
 
         return controlResponse;

--- a/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/AbstractMethod.java
@@ -60,7 +60,7 @@ import java.util.Set;
 public abstract class AbstractMethod<RequestT, ResultT> implements Method<RequestT, ResultT> {
     private static final Log LOG = LogFactory.getLog(AbstractMethod.class);
 
-    private final HttpWrapper httpWrapper;
+    protected final HttpWrapper httpWrapper;
     private Set<Class> acceptable;
 
     public AbstractMethod(HttpWrapper httpWrapper) {

--- a/src/main/java/com/nexmo/client/voice/endpoints/CreateCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/CreateCallMethod.java
@@ -32,7 +32,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -40,9 +39,9 @@ import java.io.UnsupportedEncodingException;
 public class CreateCallMethod extends AbstractMethod<Call, CallEvent> {
     private static final Log LOG = LogFactory.getLog(CreateCallMethod.class);
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/calls";
+    private static final String PATH = "/v1/calls";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
-    private String uri = DEFAULT_URI;
+    private String uri;
 
     public CreateCallMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -50,8 +49,11 @@ public class CreateCallMethod extends AbstractMethod<Call, CallEvent> {
 
     @Override
     public RequestBuilder makeRequest(Call request) throws NexmoClientException, UnsupportedEncodingException {
+        // TODO: Remove in 4.0.0 along with setUri method
+        String uri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+
         return RequestBuilder
-                .post(this.uri)
+                .post(uri)
                 .setHeader("Content-Type", "application/json")
                 .setEntity(new StringEntity(request.toJson()));
     }
@@ -67,6 +69,10 @@ public class CreateCallMethod extends AbstractMethod<Call, CallEvent> {
         return CallEvent.fromJson(json);
     }
 
+    /**
+     * @deprecated Use {@link com.nexmo.client.HttpConfig.Builder} to create an {@link com.nexmo.client.HttpConfig} object and pass into {@link com.nexmo.client.NexmoClient}
+     */
+    @Deprecated
     public void setUri(String uri) {
         this.uri = uri;
     }

--- a/src/main/java/com/nexmo/client/voice/endpoints/CreateCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/CreateCallMethod.java
@@ -39,7 +39,7 @@ import java.io.UnsupportedEncodingException;
 public class CreateCallMethod extends AbstractMethod<Call, CallEvent> {
     private static final Log LOG = LogFactory.getLog(CreateCallMethod.class);
 
-    private static final String PATH = "/v1/calls";
+    private static final String PATH = "/calls";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
     private String uri;
 
@@ -50,7 +50,7 @@ public class CreateCallMethod extends AbstractMethod<Call, CallEvent> {
     @Override
     public RequestBuilder makeRequest(Call request) throws NexmoClientException, UnsupportedEncodingException {
         // TODO: Remove in 4.0.0 along with setUri method
-        String uri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        String uri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH;
 
         return RequestBuilder
                 .post(uri)

--- a/src/main/java/com/nexmo/client/voice/endpoints/ListCallsMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/ListCallsMethod.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class ListCallsMethod extends AbstractMethod<CallsFilter, CallInfoPage> {
     private static final Log LOG = LogFactory.getLog(CreateCallMethod.class);
 
-    private static final String PATH = "/v1/calls";
+    private static final String PATH = "/calls";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
     private String uri;
 
@@ -61,7 +61,8 @@ public class ListCallsMethod extends AbstractMethod<CallsFilter, CallInfoPage> {
     public RequestBuilder makeRequest(CallsFilter filter) throws NexmoClientException, UnsupportedEncodingException {
         URIBuilder uriBuilder;
         // TODO: Remove in 4.0.0 along with setUri and getUri method
-        String uri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        String uri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH;
+
         try {
             uriBuilder = new URIBuilder(uri);
         } catch (URISyntaxException e) {

--- a/src/main/java/com/nexmo/client/voice/endpoints/ListCallsMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/ListCallsMethod.java
@@ -35,7 +35,6 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -45,9 +44,9 @@ import java.util.List;
 public class ListCallsMethod extends AbstractMethod<CallsFilter, CallInfoPage> {
     private static final Log LOG = LogFactory.getLog(CreateCallMethod.class);
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/calls";
+    private static final String PATH = "/v1/calls";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
-    private String uri = DEFAULT_URI;
+    private String uri;
 
     public ListCallsMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -61,10 +60,12 @@ public class ListCallsMethod extends AbstractMethod<CallsFilter, CallInfoPage> {
     @Override
     public RequestBuilder makeRequest(CallsFilter filter) throws NexmoClientException, UnsupportedEncodingException {
         URIBuilder uriBuilder;
+        // TODO: Remove in 4.0.0 along with setUri and getUri method
+        String uri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
         try {
-            uriBuilder = new URIBuilder(this.uri);
+            uriBuilder = new URIBuilder(uri);
         } catch (URISyntaxException e) {
-            throw new NexmoUnexpectedException("Could not parse URI: " + this.uri);
+            throw new NexmoUnexpectedException("Could not parse URI: " + uri);
         }
         if (filter != null) {
             List<NameValuePair> params = filter.toUrlParams();
@@ -81,11 +82,15 @@ public class ListCallsMethod extends AbstractMethod<CallsFilter, CallInfoPage> {
         return CallInfoPage.fromJson(json);
     }
 
+    /**
+     * @deprecated Use {@link com.nexmo.client.HttpConfig.Builder} to create an {@link com.nexmo.client.HttpConfig} object and pass into {@link com.nexmo.client.NexmoClient}
+     */
+    @Deprecated
     public void setUri(String uri) {
         this.uri = uri;
     }
 
     public String getUri() {
-        return this.uri;
+        return (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
     }
 }

--- a/src/main/java/com/nexmo/client/voice/endpoints/ReadCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/ReadCallMethod.java
@@ -29,7 +29,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 
@@ -37,9 +36,9 @@ import java.io.IOException;
 public class ReadCallMethod extends AbstractMethod<String, CallInfo> {
     private static final Log LOG = LogFactory.getLog(ReadCallMethod.class);
 
-    private static final String DEFAULT_BASE_URI = "https://api.nexmo.com/v1/calls/";
+    private static final String PATH = "/v1/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
-    private String baseUri = DEFAULT_BASE_URI;
+    private String baseUri = null;
 
     public ReadCallMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -52,8 +51,9 @@ public class ReadCallMethod extends AbstractMethod<String, CallInfo> {
 
     @Override
     public RequestBuilder makeRequest(String callId) {
-        String uri = this.baseUri + callId;
-        return RequestBuilder.get(uri);
+        // TODO: Remove in 4.0.0 along with setBaseUri and getBaseUri method
+        String baseUri = (this.baseUri != null) ? this.baseUri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        return RequestBuilder.get(baseUri + callId);
     }
 
     @Override
@@ -62,11 +62,15 @@ public class ReadCallMethod extends AbstractMethod<String, CallInfo> {
         return CallInfo.fromJson(json);
     }
 
+    /**
+     * @deprecated Use {@link com.nexmo.client.HttpConfig.Builder} to create an {@link com.nexmo.client.HttpConfig} object and pass into {@link com.nexmo.client.NexmoClient}
+     */
+    @Deprecated
     public void setBaseUri(String baseUri) {
         this.baseUri = baseUri;
     }
 
     public String getBaseUri() {
-        return baseUri;
+        return (this.baseUri != null) ? this.baseUri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
     }
 }

--- a/src/main/java/com/nexmo/client/voice/endpoints/ReadCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/ReadCallMethod.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 public class ReadCallMethod extends AbstractMethod<String, CallInfo> {
     private static final Log LOG = LogFactory.getLog(ReadCallMethod.class);
 
-    private static final String PATH = "/v1/calls/";
+    private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
     private String baseUri = null;
 
@@ -52,7 +52,9 @@ public class ReadCallMethod extends AbstractMethod<String, CallInfo> {
     @Override
     public RequestBuilder makeRequest(String callId) {
         // TODO: Remove in 4.0.0 along with setBaseUri and getBaseUri method
-        String baseUri = (this.baseUri != null) ? this.baseUri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        String baseUri = (this.baseUri != null)
+                ? this.baseUri
+                : httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH;
         return RequestBuilder.get(baseUri + callId);
     }
 

--- a/src/main/java/com/nexmo/client/voice/endpoints/StartStreamMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/StartStreamMethod.java
@@ -39,7 +39,7 @@ import java.io.UnsupportedEncodingException;
 public class StartStreamMethod extends AbstractMethod<StreamRequest, StreamResponse> {
     private static final Log LOG = LogFactory.getLog(StartStreamMethod.class);
 
-    private static final String PATH = "/v1/calls/";
+    private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
     private String uri;
 
@@ -55,7 +55,9 @@ public class StartStreamMethod extends AbstractMethod<StreamRequest, StreamRespo
     @Override
     public RequestBuilder makeRequest(StreamRequest request) throws NexmoClientException, UnsupportedEncodingException {
         // TODO: Remove in 4.0.0 along with setUri method
-        String baseUri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        String baseUri = (this.uri != null)
+                ? this.uri
+                : httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH;
         return RequestBuilder
                 .put(baseUri + request.getUuid() + "/stream")
                 .setHeader("Content-Type", "application/json")

--- a/src/main/java/com/nexmo/client/voice/endpoints/StartStreamMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/StartStreamMethod.java
@@ -32,7 +32,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -40,9 +39,9 @@ import java.io.UnsupportedEncodingException;
 public class StartStreamMethod extends AbstractMethod<StreamRequest, StreamResponse> {
     private static final Log LOG = LogFactory.getLog(StartStreamMethod.class);
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/calls/";
+    private static final String PATH = "/v1/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
-    private String uri = DEFAULT_URI;
+    private String uri;
 
     public StartStreamMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -55,8 +54,10 @@ public class StartStreamMethod extends AbstractMethod<StreamRequest, StreamRespo
 
     @Override
     public RequestBuilder makeRequest(StreamRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        String uri = this.uri + request.getUuid() + "/stream";
-        return RequestBuilder.put(uri)
+        // TODO: Remove in 4.0.0 along with setUri method
+        String baseUri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        return RequestBuilder
+                .put(baseUri + request.getUuid() + "/stream")
                 .setHeader("Content-Type", "application/json")
                 .setEntity(new StringEntity(request.toJson()));
     }
@@ -67,6 +68,10 @@ public class StartStreamMethod extends AbstractMethod<StreamRequest, StreamRespo
         return StreamResponse.fromJson(json);
     }
 
+    /**
+     * @deprecated Use {@link com.nexmo.client.HttpConfig.Builder} to create an {@link com.nexmo.client.HttpConfig} object and pass into {@link com.nexmo.client.NexmoClient}
+     */
+    @Deprecated
     public void setUri(String uri) {
         this.uri = uri;
     }

--- a/src/main/java/com/nexmo/client/voice/endpoints/StartTalkMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/StartTalkMethod.java
@@ -32,7 +32,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -40,9 +39,9 @@ import java.io.UnsupportedEncodingException;
 public class StartTalkMethod extends AbstractMethod<TalkRequest, TalkResponse> {
     private static final Log LOG = LogFactory.getLog(StartTalkMethod.class);
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/calls/";
+    private static final String PATH = "/v1/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
-    private String uri = DEFAULT_URI;
+    private String uri;
 
     public StartTalkMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -55,8 +54,10 @@ public class StartTalkMethod extends AbstractMethod<TalkRequest, TalkResponse> {
 
     @Override
     public RequestBuilder makeRequest(TalkRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        String uri = this.uri + request.getUuid() + "/talk";
-        return RequestBuilder.put(uri)
+        // TODO: Remove in 4.0.0 along with setUri method
+        String baseUri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        return RequestBuilder
+                .put(baseUri + request.getUuid() + "/talk")
                 .setHeader("Content-Type", "application/json")
                 .setEntity(new StringEntity(request.toJson()));
     }
@@ -67,6 +68,10 @@ public class StartTalkMethod extends AbstractMethod<TalkRequest, TalkResponse> {
         return TalkResponse.fromJson(json);
     }
 
+    /**
+     * @deprecated Use {@link com.nexmo.client.HttpConfig.Builder} to create an {@link com.nexmo.client.HttpConfig} object and pass into {@link com.nexmo.client.NexmoClient}
+     */
+    @Deprecated
     public void setUri(String uri) {
         this.uri = uri;
     }

--- a/src/main/java/com/nexmo/client/voice/endpoints/StartTalkMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/StartTalkMethod.java
@@ -39,7 +39,7 @@ import java.io.UnsupportedEncodingException;
 public class StartTalkMethod extends AbstractMethod<TalkRequest, TalkResponse> {
     private static final Log LOG = LogFactory.getLog(StartTalkMethod.class);
 
-    private static final String PATH = "/v1/calls/";
+    private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
     private String uri;
 
@@ -55,7 +55,9 @@ public class StartTalkMethod extends AbstractMethod<TalkRequest, TalkResponse> {
     @Override
     public RequestBuilder makeRequest(TalkRequest request) throws NexmoClientException, UnsupportedEncodingException {
         // TODO: Remove in 4.0.0 along with setUri method
-        String baseUri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        String baseUri = (this.uri != null)
+                ? this.uri
+                : httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH;
         return RequestBuilder
                 .put(baseUri + request.getUuid() + "/talk")
                 .setHeader("Content-Type", "application/json")

--- a/src/main/java/com/nexmo/client/voice/endpoints/StopStreamMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/StopStreamMethod.java
@@ -37,7 +37,7 @@ import java.io.UnsupportedEncodingException;
 public class StopStreamMethod extends AbstractMethod<String, StreamResponse> {
     private static final Log LOG = LogFactory.getLog(StopStreamMethod.class);
 
-    private static final String PATH = "/v1/calls/";
+    private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
     private String uri;
 
@@ -53,7 +53,9 @@ public class StopStreamMethod extends AbstractMethod<String, StreamResponse> {
     @Override
     public RequestBuilder makeRequest(String uuid) throws NexmoClientException, UnsupportedEncodingException {
         // TODO: Remove in 4.0.0 along with setUri method
-        String baseUri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        String baseUri = (this.uri != null)
+                ? this.uri
+                : httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH;
         return RequestBuilder.delete(baseUri + uuid + "/stream").setHeader("Content-Type", "application/json");
     }
 

--- a/src/main/java/com/nexmo/client/voice/endpoints/StopStreamMethod.java
+++ b/src/main/java/com/nexmo/client/voice/endpoints/StopStreamMethod.java
@@ -30,7 +30,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -38,9 +37,9 @@ import java.io.UnsupportedEncodingException;
 public class StopStreamMethod extends AbstractMethod<String, StreamResponse> {
     private static final Log LOG = LogFactory.getLog(StopStreamMethod.class);
 
-    private static final String DEFAULT_URI = "https://api.nexmo.com/v1/calls/";
+    private static final String PATH = "/v1/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
-    private String uri = DEFAULT_URI;
+    private String uri;
 
     public StopStreamMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -53,9 +52,9 @@ public class StopStreamMethod extends AbstractMethod<String, StreamResponse> {
 
     @Override
     public RequestBuilder makeRequest(String uuid) throws NexmoClientException, UnsupportedEncodingException {
-        String uri = this.uri + uuid + "/stream";
-        return RequestBuilder.delete(uri)
-                .setHeader("Content-Type", "application/json");
+        // TODO: Remove in 4.0.0 along with setUri method
+        String baseUri = (this.uri != null) ? this.uri : httpWrapper.getHttpConfig().getApiBaseUri() + PATH;
+        return RequestBuilder.delete(baseUri + uuid + "/stream").setHeader("Content-Type", "application/json");
     }
 
     @Override
@@ -64,6 +63,10 @@ public class StopStreamMethod extends AbstractMethod<String, StreamResponse> {
         return StreamResponse.fromJson(json);
     }
 
+    /**
+     * @deprecated Use {@link com.nexmo.client.HttpConfig.Builder} to create an {@link com.nexmo.client.HttpConfig} object and pass into {@link com.nexmo.client.NexmoClient}
+     */
+    @Deprecated
     public void setUri(String uri) {
         this.uri = uri;
     }

--- a/src/test/java/com/nexmo/client/HttpConfigTest.java
+++ b/src/test/java/com/nexmo/client/HttpConfigTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HttpConfigTest {
+    private static final String EXPECTED_DEFAULT_API_BASE_URI = "https://api.nexmo.com";
+    private static final String EXPECTED_DEFAULT_REST_BASE_URI = "https://rest.nexmo.com";
+    private static final String EXPECTED_DEFAULT_SNS_BASE_URI = "https://sns.nexmo.com";
+
+    @Test
+    public void testDefaultFactoryMethod() {
+        HttpConfig config = HttpConfig.defaultConfig();
+
+        assertEquals(EXPECTED_DEFAULT_API_BASE_URI, config.getApiBaseUri());
+        assertEquals(EXPECTED_DEFAULT_REST_BASE_URI, config.getRestBaseUri());
+        assertEquals(EXPECTED_DEFAULT_SNS_BASE_URI, config.getSnsBaseUri());
+    }
+
+    @Test
+    public void testApiBaseUriOnly() {
+        HttpConfig config = new HttpConfig.Builder().apiBaseUri("https://example.com").build();
+
+        assertEquals("https://example.com", config.getApiBaseUri());
+        assertEquals(EXPECTED_DEFAULT_REST_BASE_URI, config.getRestBaseUri());
+        assertEquals(EXPECTED_DEFAULT_SNS_BASE_URI, config.getSnsBaseUri());
+    }
+
+    @Test
+    public void testApiRestUriOnly() {
+        HttpConfig config = new HttpConfig.Builder().restBaseUri("https://example.com").build();
+
+        assertEquals(EXPECTED_DEFAULT_API_BASE_URI, config.getApiBaseUri());
+        assertEquals("https://example.com", config.getRestBaseUri());
+        assertEquals(EXPECTED_DEFAULT_SNS_BASE_URI, config.getSnsBaseUri());
+    }
+
+    @Test
+    public void testSnsBaseUriOnly() {
+        HttpConfig config = new HttpConfig.Builder().snsBaseUri("https://example.com").build();
+
+        assertEquals(EXPECTED_DEFAULT_API_BASE_URI, config.getApiBaseUri());
+        assertEquals(EXPECTED_DEFAULT_REST_BASE_URI, config.getRestBaseUri());
+        assertEquals("https://example.com", config.getSnsBaseUri());
+    }
+
+    @Test
+    public void testAllBaseUri() {
+        HttpConfig config = new HttpConfig.Builder().baseUri("https://example.com").build();
+
+        assertEquals("https://example.com", config.getApiBaseUri());
+        assertEquals("https://example.com", config.getRestBaseUri());
+        assertEquals("https://example.com", config.getSnsBaseUri());
+    }
+}

--- a/src/test/java/com/nexmo/client/HttpWrapperTest.java
+++ b/src/test/java/com/nexmo/client/HttpWrapperTest.java
@@ -30,7 +30,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class HttpWrapperTest {
+    private static final String EXPECTED_DEFAULT_API_BASE_URI = "https://api.nexmo.com";
+    private static final String EXPECTED_DEFAULT_REST_BASE_URI = "https://rest.nexmo.com";
+    private static final String EXPECTED_DEFAULT_SNS_BASE_URI = "https://sns.nexmo.com";
+
     private HttpWrapper hw;
+
     @Before
     public void setUp() {
         this.hw = new HttpWrapper(new AuthCollection());
@@ -46,5 +51,20 @@ public class HttpWrapperTest {
         AuthCollection auths = new AuthCollection();
         this.hw.setAuthCollection(auths);
         assertEquals(auths, this.hw.getAuthCollection());
+    }
+
+    @Test
+    public void testHttpConfigAccessor() {
+        assertNotNull(this.hw.getHttpConfig());
+    }
+
+    @Test
+    public void testDefaultConstructorSetsDefaultConfigValues() {
+        HttpWrapper wrapper = new HttpWrapper();
+
+        HttpConfig config = wrapper.getHttpConfig();
+        assertEquals(EXPECTED_DEFAULT_API_BASE_URI, config.getApiBaseUri());
+        assertEquals(EXPECTED_DEFAULT_REST_BASE_URI, config.getRestBaseUri());
+        assertEquals(EXPECTED_DEFAULT_SNS_BASE_URI, config.getSnsBaseUri());
     }
 }

--- a/src/test/java/com/nexmo/client/account/BalanceEndpointTest.java
+++ b/src/test/java/com/nexmo/client/account/BalanceEndpointTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.account;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.auth.TokenAuthMethod;
@@ -40,7 +42,7 @@ public class BalanceEndpointTest {
 
     @Before
     public void setUp() throws Exception {
-        this.endpoint = new BalanceEndpoint(null);
+        this.endpoint = new BalanceEndpoint(new HttpWrapper());
     }
 
     @Test
@@ -58,6 +60,16 @@ public class BalanceEndpointTest {
         Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
         assertEquals(0, params.size());
 
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        BalanceEndpoint endpoint = new BalanceEndpoint(wrapper);
+
+        RequestBuilder builder = endpoint.makeRequest(null);
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://example.com/account/get-balance", builder.build().getURI().toString());
     }
 
     @Test

--- a/src/test/java/com/nexmo/client/account/CreateSecretMethodTest.java
+++ b/src/test/java/com/nexmo/client/account/CreateSecretMethodTest.java
@@ -21,18 +21,27 @@
  */
 package com.nexmo.client.account;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class CreateSecretMethodTest {
+    private CreateSecretMethod method;
+
+    @Before
+    public void setUp() {
+        this.method = new CreateSecretMethod(new HttpWrapper());
+    }
+
     @Test
     public void testConstructParams() throws Exception {
-        CreateSecretMethod method = new CreateSecretMethod(null);
         CreateSecretRequest request = new CreateSecretRequest("account-id", "secret");
 
         RequestBuilder builder = method.makeRequest(request);
@@ -44,7 +53,6 @@ public class CreateSecretMethodTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructParamsWithMissingApiKey() throws Exception {
-        CreateSecretMethod method = new CreateSecretMethod(null);
         CreateSecretRequest request = new CreateSecretRequest(null, "secret");
 
         method.makeRequest(request);
@@ -52,9 +60,28 @@ public class CreateSecretMethodTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructParamsWithMissingSecret() throws Exception {
-        CreateSecretMethod method = new CreateSecretMethod(null);
         CreateSecretRequest request = new CreateSecretRequest("account-id", null);
 
         method.makeRequest(request);
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        CreateSecretRequest request = new CreateSecretRequest("account-id", "secret");
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/accounts/account-id/secrets", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        CreateSecretMethod method = new CreateSecretMethod(wrapper);
+        CreateSecretRequest request = new CreateSecretRequest("account-id", "secret");
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/accounts/account-id/secrets", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/account/GetSecretMethodTest.java
+++ b/src/test/java/com/nexmo/client/account/GetSecretMethodTest.java
@@ -21,9 +21,22 @@
  */
 package com.nexmo.client.account;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
+import org.apache.http.client.methods.RequestBuilder;
+import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class GetSecretMethodTest {
+    private GetSecretMethod method;
+
+    @Before
+    public void setUp() {
+        this.method = new GetSecretMethod(new HttpWrapper());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testConstructParamsWithMissingApiKey() throws Exception {
         GetSecretMethod method = new GetSecretMethod(null);
@@ -38,5 +51,25 @@ public class GetSecretMethodTest {
         SecretRequest request = new SecretRequest("api-key", null);
 
         method.makeRequest(request);
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        SecretRequest request = new SecretRequest("account-id", "secret");
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://api.nexmo.com/accounts/account-id/secrets/secret", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        GetSecretMethod method = new GetSecretMethod(wrapper);
+        SecretRequest request = new SecretRequest("account-id", "secret");
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://example.com/accounts/account-id/secrets/secret", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/account/PrefixPricingMethodTest.java
+++ b/src/test/java/com/nexmo/client/account/PrefixPricingMethodTest.java
@@ -29,33 +29,37 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class ListSecretsMethodTest {
-    ListSecretsMethod method;
+public class PrefixPricingMethodTest {
+    private PrefixPricingMethod method;
 
     @Before
-    public void setUp() throws Exception {
-        this.method = new ListSecretsMethod(new HttpWrapper());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructParamsWithMissingApiKey() throws Exception {
-        method.makeRequest(null);
+    public void setUp() {
+        this.method = new PrefixPricingMethod(new HttpWrapper());
     }
 
     @Test
     public void testDefaultUri() throws Exception {
-        RequestBuilder builder = method.makeRequest("api-key");
+        PrefixPricingRequest request = new PrefixPricingRequest(ServiceType.VOICE, "prefix");
+
+        RequestBuilder builder = method.makeRequest(request);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://api.nexmo.com/accounts/api-key/secrets", builder.build().getURI().toString());
+        assertEquals(
+                "https://rest.nexmo.com/get-prefix-pricing/outbound/voice?prefix=prefix",
+                builder.build().getURI().toString()
+        );
     }
 
     @Test
     public void testCustomUri() throws Exception {
         HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
-        ListSecretsMethod method = new ListSecretsMethod(wrapper);
+        PrefixPricingMethod method = new PrefixPricingMethod(wrapper);
+        PrefixPricingRequest request = new PrefixPricingRequest(ServiceType.VOICE, "prefix");
 
-        RequestBuilder builder = method.makeRequest("api-key");
+        RequestBuilder builder = method.makeRequest(request);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/accounts/api-key/secrets", builder.build().getURI().toString());
+        assertEquals(
+                "https://example.com/get-prefix-pricing/outbound/voice?prefix=prefix",
+                builder.build().getURI().toString()
+        );
     }
 }

--- a/src/test/java/com/nexmo/client/account/RevokeSecretMethodTest.java
+++ b/src/test/java/com/nexmo/client/account/RevokeSecretMethodTest.java
@@ -21,9 +21,22 @@
  */
 package com.nexmo.client.account;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
+import org.apache.http.client.methods.RequestBuilder;
+import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class RevokeSecretMethodTest {
+    private RevokeSecretMethod method;
+
+    @Before
+    public void setUp() {
+        this.method = new RevokeSecretMethod(new HttpWrapper());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testConstructParamsWithMissingApiKey() throws Exception {
         RevokeSecretMethod method = new RevokeSecretMethod(null);
@@ -38,5 +51,27 @@ public class RevokeSecretMethodTest {
         SecretRequest request = new SecretRequest("account-id", null);
 
         method.makeRequest(request);
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        SecretRequest request = new SecretRequest("account-id", "secret-id");
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("DELETE", builder.getMethod());
+        assertEquals("https://api.nexmo.com/accounts/account-id/secrets/secret-id",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        RevokeSecretMethod method = new RevokeSecretMethod(wrapper);
+        SecretRequest request = new SecretRequest("account-id", "secret-id");
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("DELETE", builder.getMethod());
+        assertEquals("https://example.com/accounts/account-id/secrets/secret-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/account/SmsPricingMethodTest.java
+++ b/src/test/java/com/nexmo/client/account/SmsPricingMethodTest.java
@@ -29,33 +29,36 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class ListSecretsMethodTest {
-    ListSecretsMethod method;
+public class SmsPricingMethodTest {
+    private SmsPricingMethod method;
 
     @Before
-    public void setUp() throws Exception {
-        this.method = new ListSecretsMethod(new HttpWrapper());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructParamsWithMissingApiKey() throws Exception {
-        method.makeRequest(null);
+    public void setUp() {
+        this.method = new SmsPricingMethod(new HttpWrapper());
     }
 
     @Test
     public void testDefaultUri() throws Exception {
-        RequestBuilder builder = method.makeRequest("api-key");
+        PricingRequest request = new PricingRequest("country");
+
+        RequestBuilder builder = method.makeRequest(request);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://api.nexmo.com/accounts/api-key/secrets", builder.build().getURI().toString());
+        assertEquals("https://rest.nexmo.com/account/get-pricing/outbound/sms?country=country",
+                builder.build().getURI().toString()
+        );
     }
 
     @Test
     public void testCustomUri() throws Exception {
         HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
-        ListSecretsMethod method = new ListSecretsMethod(wrapper);
+        SmsPricingMethod method = new SmsPricingMethod(wrapper);
+        PricingRequest request = new PricingRequest("country");
 
-        RequestBuilder builder = method.makeRequest("api-key");
+        RequestBuilder builder = method.makeRequest(request);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/accounts/api-key/secrets", builder.build().getURI().toString());
+        assertEquals(
+                "https://example.com/account/get-pricing/outbound/sms?country=country",
+                builder.build().getURI().toString()
+        );
     }
 }

--- a/src/test/java/com/nexmo/client/account/TopUpMethodTest.java
+++ b/src/test/java/com/nexmo/client/account/TopUpMethodTest.java
@@ -29,33 +29,33 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class ListSecretsMethodTest {
-    ListSecretsMethod method;
+public class TopUpMethodTest {
+    private TopUpMethod method;
 
     @Before
     public void setUp() throws Exception {
-        this.method = new ListSecretsMethod(new HttpWrapper());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructParamsWithMissingApiKey() throws Exception {
-        method.makeRequest(null);
+        this.method = new TopUpMethod(new HttpWrapper());
     }
 
     @Test
     public void testDefaultUri() throws Exception {
-        RequestBuilder builder = method.makeRequest("api-key");
+        TopUpRequest request = new TopUpRequest("trx");
+
+        RequestBuilder builder = method.makeRequest(request);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://api.nexmo.com/accounts/api-key/secrets", builder.build().getURI().toString());
+        assertEquals("https://rest.nexmo.com/account/top-up?trx=trx",
+                builder.build().getURI().toString()
+        );
     }
 
     @Test
     public void testCustomUri() throws Exception {
         HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
-        ListSecretsMethod method = new ListSecretsMethod(wrapper);
+        TopUpMethod method = new TopUpMethod(wrapper);
+        TopUpRequest request = new TopUpRequest("trx");
 
-        RequestBuilder builder = method.makeRequest("api-key");
+        RequestBuilder builder = method.makeRequest(request);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/accounts/api-key/secrets", builder.build().getURI().toString());
+        assertEquals("https://example.com/account/top-up?trx=trx", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/account/VoicePricingMethodTest.java
+++ b/src/test/java/com/nexmo/client/account/VoicePricingMethodTest.java
@@ -29,33 +29,36 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class ListSecretsMethodTest {
-    ListSecretsMethod method;
+public class VoicePricingMethodTest {
+    private VoicePricingMethod method;
 
     @Before
     public void setUp() throws Exception {
-        this.method = new ListSecretsMethod(new HttpWrapper());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructParamsWithMissingApiKey() throws Exception {
-        method.makeRequest(null);
+        this.method = new VoicePricingMethod(new HttpWrapper());
     }
 
     @Test
     public void testDefaultUri() throws Exception {
-        RequestBuilder builder = method.makeRequest("api-key");
+        PricingRequest request = new PricingRequest("country");
+
+        RequestBuilder builder = method.makeRequest(request);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://api.nexmo.com/accounts/api-key/secrets", builder.build().getURI().toString());
+        assertEquals("https://rest.nexmo.com/account/get-pricing/outbound/voice?country=country",
+                builder.build().getURI().toString()
+        );
     }
 
     @Test
     public void testCustomUri() throws Exception {
         HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
-        ListSecretsMethod method = new ListSecretsMethod(wrapper);
+        VoicePricingMethod method = new VoicePricingMethod(wrapper);
+        PricingRequest request = new PricingRequest("country");
 
-        RequestBuilder builder = method.makeRequest("api-key");
+        RequestBuilder builder = method.makeRequest(request);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/accounts/api-key/secrets", builder.build().getURI().toString());
+        assertEquals(
+                "https://example.com/account/get-pricing/outbound/voice?country=country",
+                builder.build().getURI().toString()
+        );
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/CreateApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/CreateApplicationMethodTest.java
@@ -159,6 +159,6 @@ public class CreateApplicationMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://example.com/v1/applications", builder.build().getURI().toString());
+        assertEquals("https://example.com/applications", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/CreateApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/CreateApplicationMethodTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.applications.endpoints;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.applications.ApplicationDetails;
 import com.nexmo.client.applications.ApplicationKeys;
@@ -41,7 +43,7 @@ public class CreateApplicationMethodTest {
 
     @Before
     public void setUp() throws Exception {
-        this.endpoint = new CreateApplicationMethod(null);
+        this.endpoint = new CreateApplicationMethod(new HttpWrapper());
     }
 
     @Test
@@ -136,5 +138,27 @@ public class CreateApplicationMethodTest {
 
         assertEquals("PUBLIC_KEY", keys.getPublicKey());
         assertEquals("PRIVATE_KEY", keys.getPrivateKey());
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        CreateApplicationRequest request = new CreateApplicationRequest("name", "answer-url", "event-url");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/applications",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        CreateApplicationMethod method = new CreateApplicationMethod(wrapper);
+        CreateApplicationRequest request = new CreateApplicationRequest("name", "answer-url", "event-url");
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/v1/applications", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethodTest.java
@@ -81,6 +81,6 @@ public class DeleteApplicationMethodTest {
 
         RequestBuilder builder = method.makeRequest("application-id");
         assertEquals("DELETE", builder.getMethod());
-        assertEquals("https://example.com/v1/applications/application-id", builder.build().getURI().toString());
+        assertEquals("https://example.com/applications/application-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethodTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.applications.endpoints;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
@@ -38,7 +40,7 @@ public class DeleteApplicationMethodTest {
 
     @Before
     public void setUp() throws Exception {
-        this.endpoint = new DeleteApplicationMethod(null);
+        this.endpoint = new DeleteApplicationMethod(new HttpWrapper());
     }
 
     @Test
@@ -61,5 +63,24 @@ public class DeleteApplicationMethodTest {
     public void testParseResponse() throws Exception {
         HttpResponse stub = TestUtils.makeJsonHttpResponse(204, "");
         this.endpoint.parseResponse(stub);
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        RequestBuilder builder = endpoint.makeRequest("application-id");
+        assertEquals("DELETE", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/applications/application-id",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        DeleteApplicationMethod method = new DeleteApplicationMethod(wrapper);
+
+        RequestBuilder builder = method.makeRequest("application-id");
+        assertEquals("DELETE", builder.getMethod());
+        assertEquals("https://example.com/v1/applications/application-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/GetApplicationEndpointTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/GetApplicationEndpointTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.applications.endpoints;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.applications.ApplicationDetails;
 import com.nexmo.client.applications.ApplicationKeys;
@@ -40,7 +42,7 @@ public class GetApplicationEndpointTest {
 
     @Before
     public void setUp() throws Exception {
-        this.endpoint = new GetApplicationEndpoint(null);
+        this.endpoint = new GetApplicationEndpoint(new HttpWrapper());
     }
 
     @Test
@@ -61,33 +63,20 @@ public class GetApplicationEndpointTest {
 
     @Test
     public void testParseResponse() throws Exception {
-        HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
-                "  \"id\": \"aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n" +
-                "  \"name\": \"My Application\",\n" +
-                "  \"voice\": {\n" +
-                "    \"webhooks\": [\n" +
-                "      {\n" +
-                "        \"endpoint_type\": \"answer_url\",\n" +
-                "        \"endpoint\": \"https://example.com/answer\",\n" +
-                "        \"http_method\": \"GET\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"endpoint_type\": \"event_url\",\n" +
-                "        \"endpoint\": \"https://example.com/event\",\n" +
-                "        \"http_method\": \"POST\"\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  },\n" +
-                "  \"keys\": {\n" +
-                "    \"public_key\": \"PUBLIC_KEY\",\n" +
-                "    \"private_key\": \"PRIVATE_KEY\"\n" +
-                "  },\n" +
-                "  \"_links\": {\n" +
-                "    \"self\": {\n" +
-                "      \"href\": \"/v1/applications/aaaaaaaa-bbbb-cccc-dddd-0123456789ab\"\n" +
-                "    }\n" +
-                "  }\n" +
-                "}");
+        HttpResponse stub = TestUtils.makeJsonHttpResponse(200,
+                "{\n" + "  \"id\": \"aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n" + "  \"name\": \"My Application\",\n"
+                        + "  \"voice\": {\n" + "    \"webhooks\": [\n" + "      {\n"
+                        + "        \"endpoint_type\": \"answer_url\",\n"
+                        + "        \"endpoint\": \"https://example.com/answer\",\n"
+                        + "        \"http_method\": \"GET\"\n" + "      },\n" + "      {\n"
+                        + "        \"endpoint_type\": \"event_url\",\n"
+                        + "        \"endpoint\": \"https://example.com/event\",\n"
+                        + "        \"http_method\": \"POST\"\n" + "      }\n" + "    ]\n" + "  },\n" + "  \"keys\": {\n"
+                        + "    \"public_key\": \"PUBLIC_KEY\",\n" + "    \"private_key\": \"PRIVATE_KEY\"\n" + "  },\n"
+                        + "  \"_links\": {\n" + "    \"self\": {\n"
+                        + "      \"href\": \"/v1/applications/aaaaaaaa-bbbb-cccc-dddd-0123456789ab\"\n" + "    }\n"
+                        + "  }\n" + "}"
+        );
         ApplicationDetails response = this.endpoint.parseResponse(stub);
         assertEquals("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", response.getId());
         assertEquals("My Application", response.getName());
@@ -110,5 +99,22 @@ public class GetApplicationEndpointTest {
 
         assertEquals("PUBLIC_KEY", keys.getPublicKey());
         assertEquals("PRIVATE_KEY", keys.getPrivateKey());
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        RequestBuilder builder = endpoint.makeRequest("application-id");
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/applications/application-id", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        GetApplicationEndpoint endpoint = new GetApplicationEndpoint(wrapper);
+
+        RequestBuilder builder = endpoint.makeRequest("application-id");
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://example.com/v1/applications/application-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/GetApplicationEndpointTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/GetApplicationEndpointTest.java
@@ -115,6 +115,6 @@ public class GetApplicationEndpointTest {
 
         RequestBuilder builder = endpoint.makeRequest("application-id");
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/v1/applications/application-id", builder.build().getURI().toString());
+        assertEquals("https://example.com/applications/application-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpointTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpointTest.java
@@ -156,7 +156,7 @@ public class ListApplicationsEndpointTest {
         RequestBuilder builder = endpoint.makeRequest(request);
         assertEquals("GET", builder.getMethod());
         assertEquals(
-                "https://example.com/v1/applications",
+                "https://example.com/applications",
                 builder.build().getURI().toString()
         );
     }
@@ -185,7 +185,7 @@ public class ListApplicationsEndpointTest {
         RequestBuilder builder = endpoint.makeRequest(request);
         assertEquals("GET", builder.getMethod());
         assertEquals(
-                "https://example.com/v1/applications?page_size=40&page_index=32",
+                "https://example.com/applications?page_size=40&page_index=32",
                 builder.build().getURI().toString()
         );
     }

--- a/src/test/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpointTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpointTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.applications.endpoints;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.applications.*;
 import com.nexmo.client.auth.TokenAuthMethod;
@@ -38,7 +40,7 @@ public class ListApplicationsEndpointTest {
 
     @Before
     public void setUp() throws Exception {
-        this.endpoint = new ListApplicationsEndpoint(null);
+        this.endpoint = new ListApplicationsEndpoint(new HttpWrapper());
     }
 
     @Test
@@ -65,7 +67,10 @@ public class ListApplicationsEndpointTest {
 
         RequestBuilder builder = this.endpoint.makeRequest(request);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://api.nexmo.com/v1/applications?page_size=40&page_index=32", builder.build().getURI().toString());
+        assertEquals(
+                "https://api.nexmo.com/v1/applications?page_size=40&page_index=32",
+                builder.build().getURI().toString()
+        );
 
         Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
         assertEquals("32", params.get("page_index"));
@@ -74,55 +79,30 @@ public class ListApplicationsEndpointTest {
 
     @Test
     public void testParseResponse() throws Exception {
-        HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
-                "  \"count\": 1,\n" +
-                "  \"page_size\": 10,\n" +
-                "  \"page_index\": 3,\n" +
-                "  \"_embedded\": {\n" +
-                "    \"applications\": [\n" +
-                "      {\n" +
-                "        \"id\": \"aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n" +
-                "        \"name\": \"My Application\",\n" +
-                "        \"voice\": {\n" +
-                "          \"webhooks\": [\n" +
-                "            {\n" +
-                "              \"endpoint_type\": \"event_url\",\n" +
-                "              \"endpoint\": \"https://example.com/event\",\n" +
-                "              \"http_method\": \"POST\"\n" +
-                "            },\n" +
-                "            {\n" +
-                "              \"endpoint_type\": \"answer_url\",\n" +
-                "              \"endpoint\": \"https://example.com/answer\",\n" +
-                "              \"http_method\": \"GET\"\n" +
-                "            }\n" +
-                "          ]\n" +
-                "        },\n" +
-                "        \"keys\": {\n" +
-                "          \"public_key\": \"PUBLIC_KEY\"\n" +
-                "        },\n" +
-                "        \"_links\": {\n" +
-                "          \"self\": {\n" +
-                "            \"href\": \"/v1/applications/aaaaaaaa-bbbb-cccc-dddd-0123456789ab\"\n" +
-                "          }\n" +
-                "        }\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  },\n" +
-                "  \"_links\": {\n" +
-                "    \"self\": {\n" +
-                "      \"href\": \"/v1/applications?page_size=10&page_index=1\"\n" +
-                "    },\n" +
-                "    \"first\": {\n" +
-                "      \"href\": \"/v1/applications?page_size=10\"\n" +
-                "    },\n" +
-                "    \"last\": {\n" +
-                "      \"href\": \"/v1/applications?page_size=10&page_index=5\"\n" +
-                "    },\n" +
-                "    \"next\": {\n" +
-                "      \"href\": \"/v1/applications?page_size=10&page_index=2\"\n" +
-                "    }\n" +
-                "  }\n" +
-                "}");
+        HttpResponse stub = TestUtils.makeJsonHttpResponse(
+                200,
+                "{\n" + "  \"count\": 1,\n" + "  \"page_size\": 10,\n" + "  \"page_index\": 3,\n"
+                        + "  \"_embedded\": {\n" + "    \"applications\": [\n" + "      {\n"
+                        + "        \"id\": \"aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n"
+                        + "        \"name\": \"My Application\",\n" + "        \"voice\": {\n"
+                        + "          \"webhooks\": [\n" + "            {\n"
+                        + "              \"endpoint_type\": \"event_url\",\n"
+                        + "              \"endpoint\": \"https://example.com/event\",\n"
+                        + "              \"http_method\": \"POST\"\n" + "            },\n" + "            {\n"
+                        + "              \"endpoint_type\": \"answer_url\",\n"
+                        + "              \"endpoint\": \"https://example.com/answer\",\n"
+                        + "              \"http_method\": \"GET\"\n" + "            }\n" + "          ]\n"
+                        + "        },\n" + "        \"keys\": {\n" + "          \"public_key\": \"PUBLIC_KEY\"\n"
+                        + "        },\n" + "        \"_links\": {\n" + "          \"self\": {\n"
+                        + "            \"href\": \"/v1/applications/aaaaaaaa-bbbb-cccc-dddd-0123456789ab\"\n"
+                        + "          }\n" + "        }\n" + "      }\n" + "    ]\n" + "  },\n" + "  \"_links\": {\n"
+                        + "    \"self\": {\n" + "      \"href\": \"/v1/applications?page_size=10&page_index=1\"\n"
+                        + "    },\n" + "    \"first\": {\n" + "      \"href\": \"/v1/applications?page_size=10\"\n"
+                        + "    },\n" + "    \"last\": {\n"
+                        + "      \"href\": \"/v1/applications?page_size=10&page_index=5\"\n" + "    },\n"
+                        + "    \"next\": {\n" + "      \"href\": \"/v1/applications?page_size=10&page_index=2\"\n"
+                        + "    }\n" + "  }\n" + "}"
+        );
         ListApplicationsResponse response = this.endpoint.parseResponse(stub);
         assertEquals(1, response.getCount());
         assertEquals(10, response.getPageSize());
@@ -154,5 +134,59 @@ public class ListApplicationsEndpointTest {
         assertNull(keys.getPrivateKey());
 
         assertEquals(response.getEmbedded().getApplicationDetails()[0], app);
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        ListApplicationsRequest request = new ListApplicationsRequest();
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/applications",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        ListApplicationsEndpoint endpoint = new ListApplicationsEndpoint(wrapper);
+        ListApplicationsRequest request = new ListApplicationsRequest();
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("GET", builder.getMethod());
+        assertEquals(
+                "https://example.com/v1/applications",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testDefaultUriWithPage() throws Exception {
+        ListApplicationsRequest request = new ListApplicationsRequest();
+        request.setPageIndex(32);
+        request.setPageSize(40);
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/applications?page_size=40&page_index=32",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUriWithPage() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        ListApplicationsEndpoint endpoint = new ListApplicationsEndpoint(wrapper);
+        ListApplicationsRequest request = new ListApplicationsRequest();
+        request.setPageIndex(32);
+        request.setPageSize(40);
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("GET", builder.getMethod());
+        assertEquals(
+                "https://example.com/v1/applications?page_size=40&page_index=32",
+                builder.build().getURI().toString()
+        );
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethodTest.java
@@ -167,6 +167,6 @@ public class UpdateApplicationMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("PUT", builder.getMethod());
-        assertEquals("https://example.com/v1/applications/app-id", builder.build().getURI().toString());
+        assertEquals("https://example.com/applications/app-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethodTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.applications.endpoints;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.applications.ApplicationDetails;
 import com.nexmo.client.applications.ApplicationKeys;
@@ -41,7 +43,7 @@ public class UpdateApplicationMethodTest {
 
     @Before
     public void setUp() throws Exception {
-        this.endpoint = new UpdateApplicationMethod(null);
+        this.endpoint = new UpdateApplicationMethod(new HttpWrapper());
     }
 
     @Test
@@ -53,7 +55,10 @@ public class UpdateApplicationMethodTest {
     @Test
     public void testMakeRequestWithOptionalParams() throws Exception {
         UpdateApplicationRequest update = new UpdateApplicationRequest(
-                "app-id", "app name", "https://example.com/answer", "https://example.com/event"
+                "app-id",
+                "app name",
+                "https://example.com/answer",
+                "https://example.com/event"
         );
         update.setAnswerMethod("PUT");
         update.setEventMethod("DELETE");
@@ -74,7 +79,10 @@ public class UpdateApplicationMethodTest {
     @Test
     public void testMakeRequest() throws Exception {
         UpdateApplicationRequest update = new UpdateApplicationRequest(
-                "app-id", "app name", "https://example.com/answer", "https://example.com/event"
+                "app-id",
+                "app name",
+                "https://example.com/answer",
+                "https://example.com/event"
         );
 
         RequestBuilder builder = this.endpoint.makeRequest(update);
@@ -92,32 +100,20 @@ public class UpdateApplicationMethodTest {
 
     @Test
     public void testParseResponse() throws Exception {
-        HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
-                "  \"id\": \"aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n" +
-                "  \"name\": \"My Application\",\n" +
-                "  \"voice\": {\n" +
-                "    \"webhooks\": [\n" +
-                "      {\n" +
-                "        \"endpoint_type\": \"answer_url\",\n" +
-                "        \"endpoint\": \"https://example.com/answer\",\n" +
-                "        \"http_method\": \"GET\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"endpoint_type\": \"event_url\",\n" +
-                "        \"endpoint\": \"https://example.com/event\",\n" +
-                "        \"http_method\": \"POST\"\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  },\n" +
-                "  \"keys\": {\n" +
-                "    \"public_key\": \"PUBLIC_KEY\"\n" +
-                "  },\n" +
-                "  \"_links\": {\n" +
-                "    \"self\": {\n" +
-                "      \"href\": \"/v1/applications/aaaaaaaa-bbbb-cccc-dddd-0123456789ab\"\n" +
-                "    }\n" +
-                "  }\n" +
-                "}");
+        HttpResponse stub = TestUtils.makeJsonHttpResponse(
+                200,
+                "{\n" + "  \"id\": \"aaaaaaaa-bbbb-cccc-dddd-0123456789ab\",\n" + "  \"name\": \"My Application\",\n"
+                        + "  \"voice\": {\n" + "    \"webhooks\": [\n" + "      {\n"
+                        + "        \"endpoint_type\": \"answer_url\",\n"
+                        + "        \"endpoint\": \"https://example.com/answer\",\n"
+                        + "        \"http_method\": \"GET\"\n" + "      },\n" + "      {\n"
+                        + "        \"endpoint_type\": \"event_url\",\n"
+                        + "        \"endpoint\": \"https://example.com/event\",\n"
+                        + "        \"http_method\": \"POST\"\n" + "      }\n" + "    ]\n" + "  },\n" + "  \"keys\": {\n"
+                        + "    \"public_key\": \"PUBLIC_KEY\"\n" + "  },\n" + "  \"_links\": {\n" + "    \"self\": {\n"
+                        + "      \"href\": \"/v1/applications/aaaaaaaa-bbbb-cccc-dddd-0123456789ab\"\n" + "    }\n"
+                        + "  }\n" + "}"
+        );
         ApplicationDetails response = this.endpoint.parseResponse(stub);
         assertEquals("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", response.getId());
         assertEquals("My Application", response.getName());
@@ -140,5 +136,37 @@ public class UpdateApplicationMethodTest {
 
         assertEquals("PUBLIC_KEY", keys.getPublicKey());
         assertNull(keys.getPrivateKey());
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        UpdateApplicationRequest request = new UpdateApplicationRequest(
+                "app-id",
+                "app name",
+                "https://example.com/answer",
+                "https://example.com/event"
+        );
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("PUT", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/applications/app-id",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        UpdateApplicationMethod method = new UpdateApplicationMethod(wrapper);
+        UpdateApplicationRequest request = new UpdateApplicationRequest(
+                "app-id",
+                "app name",
+                "https://example.com/answer",
+                "https://example.com/event"
+        );
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("PUT", builder.getMethod());
+        assertEquals("https://example.com/v1/applications/app-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/conversion/ConversionMethodTest.java
+++ b/src/test/java/com/nexmo/client/conversion/ConversionMethodTest.java
@@ -21,9 +21,12 @@
  */
 package com.nexmo.client.conversion;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.message.BasicNameValuePair;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.text.SimpleDateFormat;
@@ -33,14 +36,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ConversionMethodTest {
+    private ConversionMethod method;
+
+    @Before
+    public void setUp() throws Exception {
+        this.method = new ConversionMethod(new HttpWrapper());
+    }
+
     @Test
     public void testConstructParametersWithSms() throws Exception {
-        ConversionMethod method = new ConversionMethod(null);
         ConversionRequest request = new ConversionRequest(ConversionRequest.Type.SMS,
-                                                          "MESSAGE-ID",
-                                                          true,
-                                                          new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(
-                                                                  "2014-03-04 10:11:12"));
+                "MESSAGE-ID",
+                true,
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12")
+        );
         RequestBuilder requestBuilder = method.makeRequest(request);
         List<NameValuePair> params = requestBuilder.getParameters();
 
@@ -48,17 +57,17 @@ public class ConversionMethodTest {
         assertContainsParam(params, "delivered", "true");
         assertContainsParam(params, "timestamp", "2014-03-04 10:11:12");
         assertEquals(method.getBaseUri() + ConversionRequest.Type.SMS.name().toLowerCase(),
-                     requestBuilder.getUri().toString());
+                requestBuilder.getUri().toString()
+        );
     }
 
     @Test
     public void testConstructParametersWithVoice() throws Exception {
-        ConversionMethod method = new ConversionMethod(null);
         ConversionRequest request = new ConversionRequest(ConversionRequest.Type.VOICE,
-                                                          "MESSAGE-ID",
-                                                          true,
-                                                          new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(
-                                                                  "2014-03-04 10:11:12"));
+                "MESSAGE-ID",
+                true,
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12")
+        );
         RequestBuilder requestBuilder = method.makeRequest(request);
         List<NameValuePair> params = requestBuilder.getParameters();
 
@@ -66,11 +75,42 @@ public class ConversionMethodTest {
         assertContainsParam(params, "delivered", "true");
         assertContainsParam(params, "timestamp", "2014-03-04 10:11:12");
         assertEquals(method.getBaseUri() + ConversionRequest.Type.VOICE.name().toLowerCase(),
-                     requestBuilder.getUri().toString());
+                requestBuilder.getUri().toString()
+        );
     }
 
     private void assertContainsParam(List<NameValuePair> params, String key, String value) {
         NameValuePair item = new BasicNameValuePair(key, value);
         assertTrue("" + params + " should contain " + item, params.contains(item));
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        ConversionRequest request = new ConversionRequest(ConversionRequest.Type.VOICE,
+                "MESSAGE-ID",
+                true,
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12")
+        );
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/conversions/voice",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        ConversionMethod method = new ConversionMethod(wrapper);
+        ConversionRequest request = new ConversionRequest(ConversionRequest.Type.VOICE,
+                "MESSAGE-ID",
+                true,
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12")
+        );
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/conversions/voice", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightEndpointTest.java
+++ b/src/test/java/com/nexmo/client/insight/advanced/AdvancedInsightEndpointTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.insight.advanced;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
@@ -38,7 +40,7 @@ public class AdvancedInsightEndpointTest {
 
     @Before
     public void setUp() {
-        this.endpoint = new AdvancedInsightEndpoint(null);
+        this.endpoint = new AdvancedInsightEndpoint(new HttpWrapper());
     }
 
     @Test
@@ -73,8 +75,11 @@ public class AdvancedInsightEndpointTest {
 
     @Test
     public void testMakeRequestWithCnam() throws Exception {
-        RequestBuilder builder = this.endpoint.makeRequest(new AdvancedInsightRequest("1234", "GB",
-                "123.123.123.123", true));
+        RequestBuilder builder = this.endpoint.makeRequest(new AdvancedInsightRequest("1234",
+                "GB",
+                "123.123.123.123",
+                true
+        ));
         assertEquals("POST", builder.getMethod());
         assertEquals("https://api.nexmo.com/ni/advanced/json", builder.build().getURI().toString());
         Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
@@ -86,39 +91,46 @@ public class AdvancedInsightEndpointTest {
 
     @Test
     public void testParseResponse() throws Exception {
-        HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
-                "    \"status\": 0,\n" +
-                "    \"status_message\": \"Success\",\n" +
-                "    \"lookup_outcome\": 1,\n" +
-                "    \"lookup_outcome_message\": \"Partial success - some fields populated\",\n" +
-                "    \"request_id\": \"0c082a69-85df-4bbc-aae6-ee998e17e5a4\",\n" +
-                "    \"international_format_number\": \"441632960960\",\n" +
-                "    \"national_format_number\": \"01632 960960\",\n" +
-                "    \"country_code\": \"GB\",\n" +
-                "    \"country_code_iso3\": \"GBR\",\n" +
-                "    \"country_name\": \"United Kingdom\",\n" +
-                "    \"country_prefix\": \"44\",\n" +
-                "    \"request_price\": \"0.03000000\",\n" +
-                "    \"remaining_balance\": \"18.30908949\",\n" +
-                "    \"current_carrier\": {\n" +
-                "        \"network_code\": \"GB-FIXED-RESERVED\",\n" +
-                "        \"name\": \"United Kingdom Landline Reserved\",\n" +
-                "        \"country\": \"GB\",\n" +
-                "        \"network_type\": \"landline\"\n" +
-                "    },\n" +
-                "    \"original_carrier\": {\n" +
-                "        \"network_code\": \"GB-HAPPY-RESERVED\",\n" +
-                "        \"name\": \"United Kingdom Mobile Reserved\",\n" +
-                "        \"country\": \"GB\",\n" +
-                "        \"network_type\": \"mobile\"\n" +
-                "    },\n" +
-                "    \"valid_number\": \"valid\",\n" +
-                "    \"reachable\": \"unknown\",\n" +
-                "    \"ported\": \"assumed_not_ported\",\n" +
-                "    \"roaming\": {\"status\": \"not_roaming\"}\n" +
-                "}");
+        HttpResponse stub = TestUtils.makeJsonHttpResponse(200,
+                "{\n" + "    \"status\": 0,\n" + "    \"status_message\": \"Success\",\n"
+                        + "    \"lookup_outcome\": 1,\n"
+                        + "    \"lookup_outcome_message\": \"Partial success - some fields populated\",\n"
+                        + "    \"request_id\": \"0c082a69-85df-4bbc-aae6-ee998e17e5a4\",\n"
+                        + "    \"international_format_number\": \"441632960960\",\n"
+                        + "    \"national_format_number\": \"01632 960960\",\n" + "    \"country_code\": \"GB\",\n"
+                        + "    \"country_code_iso3\": \"GBR\",\n" + "    \"country_name\": \"United Kingdom\",\n"
+                        + "    \"country_prefix\": \"44\",\n" + "    \"request_price\": \"0.03000000\",\n"
+                        + "    \"remaining_balance\": \"18.30908949\",\n" + "    \"current_carrier\": {\n"
+                        + "        \"network_code\": \"GB-FIXED-RESERVED\",\n"
+                        + "        \"name\": \"United Kingdom Landline Reserved\",\n" + "        \"country\": \"GB\",\n"
+                        + "        \"network_type\": \"landline\"\n" + "    },\n" + "    \"original_carrier\": {\n"
+                        + "        \"network_code\": \"GB-HAPPY-RESERVED\",\n"
+                        + "        \"name\": \"United Kingdom Mobile Reserved\",\n" + "        \"country\": \"GB\",\n"
+                        + "        \"network_type\": \"mobile\"\n" + "    },\n" + "    \"valid_number\": \"valid\",\n"
+                        + "    \"reachable\": \"unknown\",\n" + "    \"ported\": \"assumed_not_ported\",\n"
+                        + "    \"roaming\": {\"status\": \"not_roaming\"}\n" + "}"
+        );
         AdvancedInsightResponse response = this.endpoint.parseResponse(stub);
         assertEquals("0c082a69-85df-4bbc-aae6-ee998e17e5a4", response.getRequestId());
+    }
 
+    @Test
+    public void testDefaultUri() throws Exception {
+        AdvancedInsightRequest request = new AdvancedInsightRequest("1234");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/ni/advanced/json", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        AdvancedInsightEndpoint endpoint = new AdvancedInsightEndpoint(wrapper);
+        AdvancedInsightRequest request = new AdvancedInsightRequest("1234");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/ni/advanced/json", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/insight/basic/BasicInsightEndpointTest.java
+++ b/src/test/java/com/nexmo/client/insight/basic/BasicInsightEndpointTest.java
@@ -105,6 +105,6 @@ public class BasicInsightEndpointTest {
 
         RequestBuilder builder = endpoint.makeRequest(request);
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://api.nexmo.com/ni/basic/json", builder.build().getURI().toString());
+        assertEquals("https://example.com/ni/basic/json", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/insight/basic/BasicInsightEndpointTest.java
+++ b/src/test/java/com/nexmo/client/insight/basic/BasicInsightEndpointTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.insight.basic;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
@@ -38,7 +40,7 @@ public class BasicInsightEndpointTest {
 
     @Before
     public void setUp() {
-        this.endpoint = new BasicInsightEndpoint(null);
+        this.endpoint = new BasicInsightEndpoint(new HttpWrapper());
     }
 
     @Test
@@ -84,4 +86,25 @@ public class BasicInsightEndpointTest {
         assertEquals("d79c3d82-e2ee-46ff-972a-97b76be419cb", response.getRequestId());
     }
 
+    @Test
+    public void testDefaultUri() throws Exception {
+        BasicInsightRequest request = new BasicInsightRequest("1234");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/ni/basic/json",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        BasicInsightEndpoint endpoint = new BasicInsightEndpoint(wrapper);
+        BasicInsightRequest request = new BasicInsightRequest("1234");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/ni/basic/json", builder.build().getURI().toString());
+    }
 }

--- a/src/test/java/com/nexmo/client/insight/standard/StandardInsightEndpointTest.java
+++ b/src/test/java/com/nexmo/client/insight/standard/StandardInsightEndpointTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.insight.standard;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
@@ -38,7 +40,7 @@ public class StandardInsightEndpointTest {
 
     @Before
     public void setUp() {
-        this.endpoint = new StandardInsightEndpoint(null);
+        this.endpoint = new StandardInsightEndpoint(new HttpWrapper());
     }
 
     @Test
@@ -80,33 +82,46 @@ public class StandardInsightEndpointTest {
 
     @Test
     public void testParseResponse() throws Exception {
-        HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
-                "    \"status\": 0,\n" +
-                "    \"status_message\": \"Success\",\n" +
-                "    \"request_id\": \"34564b7d-df8b-47fd-aa07-b722602dd974\",\n" +
-                "    \"international_format_number\": \"441632960960\",\n" +
-                "    \"national_format_number\": \"01632 960960\",\n" +
-                "    \"country_code\": \"GB\",\n" +
-                "    \"country_code_iso3\": \"GBR\",\n" +
-                "    \"country_name\": \"United Kingdom\",\n" +
-                "    \"country_prefix\": \"44\",\n" +
-                "    \"request_price\": \"0.00500000\",\n" +
-                "    \"remaining_balance\": \"18.34408949\",\n" +
-                "    \"current_carrier\": {\n" +
-                "        \"network_code\": \"GB-FIXED-RESERVED\",\n" +
-                "        \"name\": \"United Kingdom Landline Reserved\",\n" +
-                "        \"country\": \"GB\",\n" +
-                "        \"network_type\": \"landline\"\n" +
-                "    },\n" +
-                "    \"original_carrier\": {\n" +
-                "        \"network_code\": \"GB-HAPPY-RESERVED\",\n" +
-                "        \"name\": \"United Kingdom Mobile Reserved\",\n" +
-                "        \"country\": \"GB\",\n" +
-                "        \"network_type\": \"mobile\"\n" +
-                "    },\n" +
-                "    \"ported\": \"assumed_not_ported\"\n" +
-                "}");
+        HttpResponse stub = TestUtils.makeJsonHttpResponse(
+                200,
+                "{\n" + "    \"status\": 0,\n" + "    \"status_message\": \"Success\",\n"
+                        + "    \"request_id\": \"34564b7d-df8b-47fd-aa07-b722602dd974\",\n"
+                        + "    \"international_format_number\": \"441632960960\",\n"
+                        + "    \"national_format_number\": \"01632 960960\",\n" + "    \"country_code\": \"GB\",\n"
+                        + "    \"country_code_iso3\": \"GBR\",\n" + "    \"country_name\": \"United Kingdom\",\n"
+                        + "    \"country_prefix\": \"44\",\n" + "    \"request_price\": \"0.00500000\",\n"
+                        + "    \"remaining_balance\": \"18.34408949\",\n" + "    \"current_carrier\": {\n"
+                        + "        \"network_code\": \"GB-FIXED-RESERVED\",\n"
+                        + "        \"name\": \"United Kingdom Landline Reserved\",\n" + "        \"country\": \"GB\",\n"
+                        + "        \"network_type\": \"landline\"\n" + "    },\n" + "    \"original_carrier\": {\n"
+                        + "        \"network_code\": \"GB-HAPPY-RESERVED\",\n"
+                        + "        \"name\": \"United Kingdom Mobile Reserved\",\n" + "        \"country\": \"GB\",\n"
+                        + "        \"network_type\": \"mobile\"\n" + "    },\n"
+                        + "    \"ported\": \"assumed_not_ported\"\n" + "}"
+        );
         StandardInsightResponse response = this.endpoint.parseResponse(stub);
         assertEquals("34564b7d-df8b-47fd-aa07-b722602dd974", response.getRequestId());
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        StandardInsightRequest request = new StandardInsightRequest("1234");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/ni/standard/json",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        StandardInsightEndpoint endpoint = new StandardInsightEndpoint(wrapper);
+        StandardInsightRequest request = new StandardInsightRequest("1234");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/ni/standard/json", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/numbers/CancelNumberEndpointTest.java
+++ b/src/test/java/com/nexmo/client/numbers/CancelNumberEndpointTest.java
@@ -21,10 +21,9 @@
  */
 package com.nexmo.client.numbers;
 
-import com.nexmo.client.NexmoBadRequestException;
-import com.nexmo.client.NexmoMethodFailedException;
-import com.nexmo.client.TestUtils;
+import com.nexmo.client.*;
 import org.apache.http.client.methods.RequestBuilder;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Map;
@@ -35,11 +34,16 @@ import static org.junit.Assert.assertEquals;
 
 
 public class CancelNumberEndpointTest {
+    CancelNumberEndpoint endpoint;
+
+    @Before
+    public void setUp() throws Exception {
+        this.endpoint = new CancelNumberEndpoint(new HttpWrapper());
+    }
+
     @Test
     public void makeRequest() throws Exception {
-        CancelNumberEndpoint methodUnderTest = new CancelNumberEndpoint(null);
-
-        RequestBuilder request = methodUnderTest.makeRequest(new CancelNumberRequest("AA", "447700900000"));
+        RequestBuilder request = endpoint.makeRequest(new CancelNumberRequest("AA", "447700900000"));
 
         assertEquals("POST", request.getMethod());
         Map<String, String> params = TestUtils.makeParameterMap(request.getParameters());
@@ -49,30 +53,19 @@ public class CancelNumberEndpointTest {
 
     @Test
     public void parseResponse() throws Exception {
-        CancelNumberEndpoint methodUnderTest = new CancelNumberEndpoint(null);
-        String json = "{\n" +
-                "  \"error-code\":\"200\",\n" +
-                "  \"error-code-label\":\"success\"\n" +
-                "}";
+        String json = "{\n" + "  \"error-code\":\"200\",\n" + "  \"error-code-label\":\"success\"\n" + "}";
 
-        CancelNumberResponse response = methodUnderTest.parseResponse(TestUtils.makeJsonHttpResponse(200, json));
+        CancelNumberResponse response = endpoint.parseResponse(TestUtils.makeJsonHttpResponse(200, json));
         assertEquals("200", response.getErrorCode());
         assertEquals("success", response.getErrorCodeLabel());
     }
 
     @Test
     public void parseBadRequestResponse() throws Exception {
-        CancelNumberEndpoint methodUnderTest = new CancelNumberEndpoint(null);
-
-        String json = "{\n" +
-                "    \"error_title\": \"Bad Request\",\n" +
-                "    \"invalid_parameters\": {\n" +
-                "        \"country\": \"Is required.\"\n" +
-                "    },\n" +
-                "    \"type\": \"BAD_REQUEST\"\n" +
-                "}";
+        String json = "{\n" + "    \"error_title\": \"Bad Request\",\n" + "    \"invalid_parameters\": {\n"
+                + "        \"country\": \"Is required.\"\n" + "    },\n" + "    \"type\": \"BAD_REQUEST\"\n" + "}";
         try {
-            methodUnderTest.parseResponse(TestUtils.makeJsonHttpResponse(400, json));
+            endpoint.parseResponse(TestUtils.makeJsonHttpResponse(400, json));
             fail("A 400 response should raise a NexmoBadRequestException");
         } catch (NexmoBadRequestException e) {
             // This is expected
@@ -81,16 +74,10 @@ public class CancelNumberEndpointTest {
 
     @Test
     public void parseMethodFailedResponse() throws Exception {
-        CancelNumberEndpoint methodUnderTest = new CancelNumberEndpoint(null);
-        String json = "{\n" +
-                "    \"error_title\": \"Bad Request\",\n" +
-                "    \"invalid_parameters\": {\n" +
-                "        \"country\": \"Is required.\"\n" +
-                "    },\n" +
-                "    \"type\": \"BAD_REQUEST\"\n" +
-                "}";
+        String json = "{\n" + "    \"error_title\": \"Bad Request\",\n" + "    \"invalid_parameters\": {\n"
+                + "        \"country\": \"Is required.\"\n" + "    },\n" + "    \"type\": \"BAD_REQUEST\"\n" + "}";
         try {
-            methodUnderTest.parseResponse(TestUtils.makeJsonHttpResponse(500, json));
+            endpoint.parseResponse(TestUtils.makeJsonHttpResponse(500, json));
             fail("A 500 response should raise a NexmoMethodFailedException");
         } catch (NexmoMethodFailedException e) {
             // This is expected
@@ -100,5 +87,25 @@ public class CancelNumberEndpointTest {
     @Test
     public void testRequestThrottleResponse() throws Exception {
         test429(new CancelNumberEndpoint(null));
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        CancelNumberRequest request = new CancelNumberRequest("AA", "447700900000");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://rest.nexmo.com/number/cancel", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        CancelNumberEndpoint endpoint = new CancelNumberEndpoint(wrapper);
+        CancelNumberRequest request = new CancelNumberRequest("AA", "447700900000");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/number/cancel", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/numbers/SearchNumbersEndpointTest.java
+++ b/src/test/java/com/nexmo/client/numbers/SearchNumbersEndpointTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.numbers;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
@@ -28,6 +30,7 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -41,17 +44,22 @@ import static org.junit.Assert.assertNull;
 
 
 public class SearchNumbersEndpointTest {
+    private SearchNumbersEndpoint endpoint;
+
+    @Before
+    public void setUp() throws Exception {
+        this.endpoint = new SearchNumbersEndpoint(new HttpWrapper());
+    }
+
     @Test
     public void makeRequest() throws Exception {
-        SearchNumbersEndpoint methodUnderTest = new SearchNumbersEndpoint(null);
-
         SearchNumbersFilter filter = new SearchNumbersFilter("BB");
         filter.setIndex(10);
         filter.setSize(20);
         filter.setPattern("234");
         filter.setFeatures(new String[]{"SMS", "VOICE"});
         filter.setSearchPattern(SearchPattern.STARTS_WITH);
-        RequestBuilder request = methodUnderTest.makeRequest(filter);
+        RequestBuilder request = endpoint.makeRequest(filter);
 
         assertEquals("GET", request.getMethod());
         Map<String, String> params = TestUtils.makeParameterMap(request.getParameters());
@@ -65,10 +73,8 @@ public class SearchNumbersEndpointTest {
 
     @Test
     public void testNullFeatureParam() throws Exception {
-        SearchNumbersEndpoint methodUnderTest = new SearchNumbersEndpoint(null);
-
         SearchNumbersFilter filter = new SearchNumbersFilter("BB");
-        RequestBuilder request = methodUnderTest.makeRequest(filter);
+        RequestBuilder request = endpoint.makeRequest(filter);
 
         Map<String, String> params = TestUtils.makeParameterMap(request.getParameters());
         assertEquals("BB", params.get("country"));
@@ -77,11 +83,9 @@ public class SearchNumbersEndpointTest {
 
     @Test
     public void testEmptyFeature() throws Exception {
-        SearchNumbersEndpoint methodUnderTest = new SearchNumbersEndpoint(null);
-
         SearchNumbersFilter filter = new SearchNumbersFilter("BB");
         filter.setFeatures(new String[]{});
-        RequestBuilder request = methodUnderTest.makeRequest(filter);
+        RequestBuilder request = endpoint.makeRequest(filter);
 
         Map<String, String> params = TestUtils.makeParameterMap(request.getParameters());
         assertEquals("BB", params.get("country"));
@@ -90,38 +94,62 @@ public class SearchNumbersEndpointTest {
 
     @Test
     public void testParseResponse() throws Exception {
-        SearchNumbersEndpoint methodUnderTest = new SearchNumbersEndpoint(null);
+        HttpResponse stubResponse = new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("1.1", 1, 1),
+                200,
+                "OK"
+        ));
 
-        HttpResponse stubResponse = new BasicHttpResponse(
-                new BasicStatusLine(new ProtocolVersion("1.1", 1, 1), 200, "OK")
-        );
-
-        String json = "{\n" +
-                "  \"count\": 4,\n" +
-                "  \"numbers\": [\n" +
-                "    {\n" +
-                "      \"country\": \"GB\",\n" +
-                "      \"msisdn\": \"447700900000\",\n" +
-                "      \"cost\": \"0.50\",\n" +
-                "      \"type\": \"mobile\",\n" +
-                "      \"features\": [\n" +
-                "        \"VOICE\",\n" +
-                "        \"SMS\"\n" +
-                "      ]\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
+        String json = "{\n" + "  \"count\": 4,\n" + "  \"numbers\": [\n" + "    {\n" + "      \"country\": \"GB\",\n"
+                + "      \"msisdn\": \"447700900000\",\n" + "      \"cost\": \"0.50\",\n"
+                + "      \"type\": \"mobile\",\n" + "      \"features\": [\n" + "        \"VOICE\",\n"
+                + "        \"SMS\"\n" + "      ]\n" + "    }\n" + "  ]\n" + "}";
         InputStream jsonStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
         BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(jsonStream);
         stubResponse.setEntity(entity);
 
-        SearchNumbersResponse response = methodUnderTest.parseResponse(stubResponse);
+        SearchNumbersResponse response = endpoint.parseResponse(stubResponse);
         assertEquals(4, response.getCount());
     }
 
     @Test
     public void testRequestThrottleResponse() throws Exception {
         test429(new SearchNumbersEndpoint(null));
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        SearchNumbersFilter filter = new SearchNumbersFilter("BB");
+        filter.setIndex(10);
+        filter.setSize(20);
+        filter.setPattern("234");
+        filter.setFeatures(new String[]{"SMS", "VOICE"});
+        filter.setSearchPattern(SearchPattern.STARTS_WITH);
+
+        RequestBuilder builder = endpoint.makeRequest(filter);
+        assertEquals("GET", builder.getMethod());
+        assertEquals(
+                "https://rest.nexmo.com/number/search?country=BB&features=SMS%2CVOICE&index=10&size=20&pattern=234&search_pattern=0",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        SearchNumbersEndpoint endpoint = new SearchNumbersEndpoint(wrapper);
+        SearchNumbersFilter filter = new SearchNumbersFilter("BB");
+        filter.setIndex(10);
+        filter.setSize(20);
+        filter.setPattern("234");
+        filter.setFeatures(new String[]{"SMS", "VOICE"});
+        filter.setSearchPattern(SearchPattern.STARTS_WITH);
+
+        RequestBuilder builder = endpoint.makeRequest(filter);
+        assertEquals("GET", builder.getMethod());
+        assertEquals(
+                "https://example.com/number/search?country=BB&features=SMS%2CVOICE&index=10&size=20&pattern=234&search_pattern=0",
+                builder.build().getURI().toString()
+        );
     }
 }

--- a/src/test/java/com/nexmo/client/redact/RedactMethodTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactMethodTest.java
@@ -102,6 +102,6 @@ public class RedactMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://example.com/v1/redact/transaction", builder.build().getURI().toString());
+        assertEquals("https://example.com/redact/transaction", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/redact/RedactMethodTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactMethodTest.java
@@ -21,18 +21,27 @@
  */
 package com.nexmo.client.redact;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class RedactMethodTest {
+    private RedactMethod method;
+
+    @Before
+    public void setUp() throws Exception {
+        this.method = new RedactMethod(new HttpWrapper());
+    }
+
     @Test
     public void testConstructParamsWithoutType() throws Exception {
-        RedactMethod method = new RedactMethod(null);
         RedactRequest request = new RedactRequest("test-id", RedactRequest.Product.VOICE);
 
         RequestBuilder builder = method.makeRequest(request);
@@ -44,7 +53,6 @@ public class RedactMethodTest {
 
     @Test
     public void testConstructParamsWithType() throws Exception {
-        RedactMethod method = new RedactMethod(null);
         RedactRequest request = new RedactRequest("test-id", RedactRequest.Product.SMS);
         request.setType(RedactRequest.Type.INBOUND);
 
@@ -57,7 +65,6 @@ public class RedactMethodTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructParamsWithMissingId() throws Exception {
-        RedactMethod method = new RedactMethod(null);
         RedactRequest request = new RedactRequest(null, RedactRequest.Product.SMS);
 
         method.makeRequest(request);
@@ -66,7 +73,6 @@ public class RedactMethodTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructParamsWithMissingProduct() throws Exception {
-        RedactMethod method = new RedactMethod(null);
         RedactRequest request = new RedactRequest("test-id", null);
 
         method.makeRequest(request);
@@ -74,9 +80,28 @@ public class RedactMethodTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructParamsWithMissingTypeAndSmsProduct() throws Exception {
-        RedactMethod method = new RedactMethod(null);
         RedactRequest request = new RedactRequest("test-id", RedactRequest.Product.SMS);
 
         method.makeRequest(request);
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        RedactRequest request = new RedactRequest("test-id", RedactRequest.Product.VOICE);
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/redact/transaction", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        RedactMethod method = new RedactMethod(wrapper);
+        RedactRequest request = new RedactRequest("test-id", RedactRequest.Product.VOICE);
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/v1/redact/transaction", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/sms/SearchSmsEndpointTest.java
+++ b/src/test/java/com/nexmo/client/sms/SearchSmsEndpointTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.sms;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
@@ -42,7 +44,7 @@ public class SearchSmsEndpointTest {
 
     @Before
     public void setUp() throws Exception {
-        this.endpoint = new SmsSearchEndpoint(null);
+        this.endpoint = new SmsSearchEndpoint(new HttpWrapper());
     }
 
     @Test
@@ -84,10 +86,11 @@ public class SearchSmsEndpointTest {
 
     @Test
     public void testMakeDateRequest() throws Exception {
-        SmsDateSearchRequest request = new SmsDateSearchRequest(
-                new GregorianCalendar(2017, GregorianCalendar.SEPTEMBER, 22).getTime(),
-                "447700900510"
-        );
+        SmsDateSearchRequest request = new SmsDateSearchRequest(new GregorianCalendar(
+                2017,
+                GregorianCalendar.SEPTEMBER,
+                22
+        ).getTime(), "447700900510");
         RequestBuilder builder = this.endpoint.makeRequest(request);
         assertEquals("GET", builder.getMethod());
         assertThat(builder.build().getURI().toString(), startsWith("https://rest.nexmo.com/search/messages?"));
@@ -100,39 +103,22 @@ public class SearchSmsEndpointTest {
 
     @Test
     public void testParseResponse() throws Exception {
-        HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
-                "  \"count\": 2,\n" +
-                "  \"items\": [\n" +
-                "    {\n" +
-                "      \"message-id\": \"00A0B0C0\",\n" +
-                "      \"account-id\": \"key\",\n" +
-                "      \"network\": \"20810\",\n" +
-                "      \"from\": \"MyApp\",\n" +
-                "      \"to\": \"123456890\",\n" +
-                "      \"body\": \"hello world\",\n" +
-                "      \"price\": \"0.04500000\",\n" +
-                "      \"date-received\": \"2011-11-25 16:03:00\",\n" +
-                "      \"final-status\": \"DELIVRD\",\n" +
-                "      \"date-closed\": \"2011-11-25 16:03:00\",\n" +
-                "      \"latency\": 11151,\n" +
-                "      \"type\": \"MT\"\n" +
-                "    },\n" +
-                "    {\n" +
-                "      \"message-id\": \"00A0B0C1\",\n" +
-                "      \"account-id\": \"key\",\n" +
-                "      \"network\": \"20810\",\n" +
-                "      \"from\": \"MyApp\",\n" +
-                "      \"to\": \"123456891\",\n" +
-                "      \"body\": \"foo bar\",\n" +
-                "      \"price\": \"0.04500000\",\n" +
-                "      \"date-received\": \"2011-11-25 17:03:00\",\n" +
-                "      \"final-status\": \"DELIVRD\",\n" +
-                "      \"date-closed\": \"2011-11-25 18:03:00\",\n" +
-                "      \"latency\": 14151,\n" +
-                "      \"type\": \"MT\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}\n");
+        HttpResponse stub = TestUtils.makeJsonHttpResponse(
+                200,
+                "{\n" + "  \"count\": 2,\n" + "  \"items\": [\n" + "    {\n" + "      \"message-id\": \"00A0B0C0\",\n"
+                        + "      \"account-id\": \"key\",\n" + "      \"network\": \"20810\",\n"
+                        + "      \"from\": \"MyApp\",\n" + "      \"to\": \"123456890\",\n"
+                        + "      \"body\": \"hello world\",\n" + "      \"price\": \"0.04500000\",\n"
+                        + "      \"date-received\": \"2011-11-25 16:03:00\",\n"
+                        + "      \"final-status\": \"DELIVRD\",\n" + "      \"date-closed\": \"2011-11-25 16:03:00\",\n"
+                        + "      \"latency\": 11151,\n" + "      \"type\": \"MT\"\n" + "    },\n" + "    {\n"
+                        + "      \"message-id\": \"00A0B0C1\",\n" + "      \"account-id\": \"key\",\n"
+                        + "      \"network\": \"20810\",\n" + "      \"from\": \"MyApp\",\n"
+                        + "      \"to\": \"123456891\",\n" + "      \"body\": \"foo bar\",\n"
+                        + "      \"price\": \"0.04500000\",\n" + "      \"date-received\": \"2011-11-25 17:03:00\",\n"
+                        + "      \"final-status\": \"DELIVRD\",\n" + "      \"date-closed\": \"2011-11-25 18:03:00\",\n"
+                        + "      \"latency\": 14151,\n" + "      \"type\": \"MT\"\n" + "    }\n" + "  ]\n" + "}\n"
+        );
         SearchSmsResponse response = this.endpoint.parseResponse(stub);
 
         assertThat(response.getCount(), equalTo(2));
@@ -145,16 +131,32 @@ public class SearchSmsEndpointTest {
         assertEquals("123456890", details.getTo());
         assertEquals("hello world", details.getBody());
         assertEquals("0.04500000", details.getPrice());
-        assertEquals(
-                new GregorianCalendar(2011, Calendar.NOVEMBER, 25, 16, 03, 00).getTime(),
-                details.getDateReceived());
+        assertEquals(new GregorianCalendar(2011, Calendar.NOVEMBER, 25, 16, 03, 00).getTime(),
+                details.getDateReceived()
+        );
         assertEquals("DELIVRD", details.getFinalStatus());
-        assertEquals(
-                new GregorianCalendar(2011, Calendar.NOVEMBER, 25, 16, 03, 00).getTime(),
-                details.getDateClosed());
+        assertEquals(new GregorianCalendar(2011, Calendar.NOVEMBER, 25, 16, 03, 00).getTime(), details.getDateClosed());
         assertEquals(11151, details.getLatency().longValue());
         assertEquals("MT", details.getType());
+    }
 
+    @Test
+    public void testDefaultUri() throws Exception {
+        SmsIdSearchRequest request = new SmsIdSearchRequest("one-id");
 
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://rest.nexmo.com/search/messages?ids=one-id", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        SmsSearchEndpoint endpoint = new SmsSearchEndpoint(wrapper);
+        SmsIdSearchRequest request = new SmsIdSearchRequest("one-id");
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://example.com/search/messages?ids=one-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/sms/SendMessageEndpointTest.java
+++ b/src/test/java/com/nexmo/client/sms/SendMessageEndpointTest.java
@@ -21,6 +21,7 @@
  */
 package com.nexmo.client.sms;
 
+import com.nexmo.client.HttpConfig;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoResponseParseException;
 import com.nexmo.client.TestUtils;
@@ -54,7 +55,7 @@ public class SendMessageEndpointTest {
 
     @Before
     public void setUp() throws ParserConfigurationException {
-        endpoint = new SendMessageEndpoint(null);
+        endpoint = new SendMessageEndpoint(new HttpWrapper());
     }
 
     @Test
@@ -133,27 +134,19 @@ public class SendMessageEndpointTest {
 
     @Test
     public void testParseResponse() throws NexmoResponseParseException {
-        SmsSubmissionResult[] rs = endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                "<mt-submission-response>\n" +
-                "    <messages count='2'>\n" +
-                "        <message>\n" +
-                "            <to>not-a-number</to>\n" +
-                "            <messageId>message-id-1</messageId>\n" +
-                "            <status>0</status>\n" +
-                "            <remainingBalance>26.43133450</remainingBalance>\n" +
-                "            <messagePrice>0.03330000</messagePrice>\n" +
-                "            <network>12345</network>\n" +
-                "        </message>\n" +
-                "        <message>\n" +
-                "            <to>not-a-number</to>\n" +
-                "            <messageId>message-id-2</messageId>\n" +
-                "            <status>0</status>\n" +
-                "            <remainingBalance>26.39803450</remainingBalance>\n" +
-                "            <messagePrice>0.03330000</messagePrice>\n" +
-                "            <network>12345</network>\n" +
-                "        </message>\n" +
-                "    </messages>\n" +
-                "</mt-submission-response>");
+        SmsSubmissionResult[] rs = endpoint.parseResponse(
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='2'>\n" + "        <message>\n" + "            <to>not-a-number</to>\n"
+                        + "            <messageId>message-id-1</messageId>\n" + "            <status>0</status>\n"
+                        + "            <remainingBalance>26.43133450</remainingBalance>\n"
+                        + "            <messagePrice>0.03330000</messagePrice>\n"
+                        + "            <network>12345</network>\n" + "        </message>\n" + "        <message>\n"
+                        + "            <to>not-a-number</to>\n" + "            <messageId>message-id-2</messageId>\n"
+                        + "            <status>0</status>\n"
+                        + "            <remainingBalance>26.39803450</remainingBalance>\n"
+                        + "            <messagePrice>0.03330000</messagePrice>\n"
+                        + "            <network>12345</network>\n" + "        </message>\n" + "    </messages>\n"
+                        + "</mt-submission-response>");
         assertEquals(rs.length, 2);
 
         SmsSubmissionResult r = rs[1];
@@ -162,46 +155,32 @@ public class SendMessageEndpointTest {
 
     @Test
     public void testParseResponseInvalidStatus() throws Exception {
-        SmsSubmissionResult[] rs = endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                "<mt-submission-response>\n" +
-                "    <messages count='2'>\n" +
-                "        <message>\n" +
-                "            <to>not-a-number</to>\n" +
-                "            <messageId>message-id-1</messageId>\n" +
-                "            <status>this-should-be-a-number</status>\n" +
-                "            <remainingBalance>26.43133450</remainingBalance>\n" +
-                "            <messagePrice>0.03330000</messagePrice>\n" +
-                "            <network>12345</network>\n" +
-                "            <clientRef>abcde</clientRef>\n" +
-                "        </message>\n" +
-                "        <message>\n" +
-                "            <to>not-a-number</to>\n" +
-                "            <messageId>message-id-2</messageId>\n" +
-                "            <status>0</status>\n" +
-                "            <remainingBalance>26.39803450</remainingBalance>\n" +
-                "            <messagePrice>0.03330000</messagePrice>\n" +
-                "            <network>12345</network>\n" +
-                "        </message>\n" +
-                "    </messages>\n" +
-                "</mt-submission-response>");
+        SmsSubmissionResult[] rs = endpoint.parseResponse(
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='2'>\n" + "        <message>\n" + "            <to>not-a-number</to>\n"
+                        + "            <messageId>message-id-1</messageId>\n"
+                        + "            <status>this-should-be-a-number</status>\n"
+                        + "            <remainingBalance>26.43133450</remainingBalance>\n"
+                        + "            <messagePrice>0.03330000</messagePrice>\n"
+                        + "            <network>12345</network>\n" + "            <clientRef>abcde</clientRef>\n"
+                        + "        </message>\n" + "        <message>\n" + "            <to>not-a-number</to>\n"
+                        + "            <messageId>message-id-2</messageId>\n" + "            <status>0</status>\n"
+                        + "            <remainingBalance>26.39803450</remainingBalance>\n"
+                        + "            <messagePrice>0.03330000</messagePrice>\n"
+                        + "            <network>12345</network>\n" + "        </message>\n" + "    </messages>\n"
+                        + "</mt-submission-response>");
         assertEquals(SmsSubmissionResult.STATUS_INTERNAL_ERROR, rs[0].getStatus());
     }
 
     @Test
     public void testParseResponseStatusMissing() throws Exception {
         try {
-            endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                    "<mt-submission-response>\n" +
-                    "    <messages count='1'>\n" +
-                    "        <message>\n" +
-                    "            <to>not-a-number</to>\n" +
-                    "            <messageId>message-id-1</messageId>\n" +
-                    "            <remainingBalance>26.43133450</remainingBalance>\n" +
-                    "            <messagePrice>0.03330000</messagePrice>\n" +
-                    "            <network>12345</network>\n" +
-                    "        </message>\n" +
-                    "    </messages>\n" +
-                    "</mt-submission-response>");
+            endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                    + "    <messages count='1'>\n" + "        <message>\n" + "            <to>not-a-number</to>\n"
+                    + "            <messageId>message-id-1</messageId>\n"
+                    + "            <remainingBalance>26.43133450</remainingBalance>\n"
+                    + "            <messagePrice>0.03330000</messagePrice>\n" + "            <network>12345</network>\n"
+                    + "        </message>\n" + "    </messages>\n" + "</mt-submission-response>");
             fail("A missing <status> should result in a NexmoResponseParseException being thrown");
         } catch (NexmoResponseParseException e) {
             // this is expected
@@ -210,23 +189,16 @@ public class SendMessageEndpointTest {
 
     @Test
     public void testParseResponseMissingValues() throws Exception {
-        SmsSubmissionResult[] rs = endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                "<mt-submission-response>\n" +
-                "    <messages count='1'>\n" +
-                "        <message>\n" +
-                "            <to></to>\n" +
-                "            <messageId></messageId>\n" +
-                "            <status></status>\n" +
-                "            <remainingBalance></remainingBalance>\n" +
-                "            <messagePrice></messagePrice>\n" +
-                "            <network></network>\n" +
-                "            <errorText></errorText>\n" +
-                "            <clientRef></clientRef>\n" +
-                "            <errorText></errorText>\n" +
-                "        </message>\n" +
-                "    </messages>\n" +
+        SmsSubmissionResult[] rs = endpoint.parseResponse(
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='1'>\n" + "        <message>\n" + "            <to></to>\n"
+                        + "            <messageId></messageId>\n" + "            <status></status>\n"
+                        + "            <remainingBalance></remainingBalance>\n"
+                        + "            <messagePrice></messagePrice>\n" + "            <network></network>\n"
+                        + "            <errorText></errorText>\n" + "            <clientRef></clientRef>\n"
+                        + "            <errorText></errorText>\n" + "        </message>\n" + "    </messages>\n" +
 
-                "</mt-submission-response>");
+                        "</mt-submission-response>");
         assertNull(rs[0].getMessageId());
         assertNull(rs[0].getDestination());
         assertEquals(SmsSubmissionResult.STATUS_INTERNAL_ERROR, rs[0].getStatus());
@@ -239,94 +211,67 @@ public class SendMessageEndpointTest {
 
     @Test
     public void testParseResponseError() throws Exception {
-        SmsSubmissionResult[] rs = endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                "<mt-submission-response>\n" +
-                "    <messages count='1'>\n" +
-                "        <message>\n" +
-                "            <status>6</status>\n" +
-                "            <errorText>The message was invalid</errorText>\n" +
-                "        </message>\n" +
-                "    </messages>\n" +
-                "</mt-submission-response>");
+        SmsSubmissionResult[] rs = endpoint.parseResponse(
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='1'>\n" + "        <message>\n" + "            <status>6</status>\n"
+                        + "            <errorText>The message was invalid</errorText>\n" + "        </message>\n"
+                        + "    </messages>\n" + "</mt-submission-response>");
         assertEquals(SmsSubmissionResult.STATUS_INVALID_MESSAGE, rs[0].getStatus());
     }
 
     @Test
     public void testParseResponseUnexpectedNode() throws Exception {
-        SmsSubmissionResult[] rs = endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                "<mt-submission-response>\n" +
-                "    <messages count='1'>\n" +
-                "        <message>\n" +
-                "            <status>0</status>\n" +
-                "            <to>not-a-number</to>\n" +
-                "            <messageId>message-id-1</messageId>\n" +
-                "            <remainingBalance>26.43133450</remainingBalance>\n" +
-                "            <messagePrice>0.03330000</messagePrice>\n" +
-                "            <network>12345</network>\n" +
-                "            <WHATISTHIS></WHATISTHIS>\n" +
-                "        </message>\n" +
-                "    </messages>\n" +
-                "</mt-submission-response>");
+        SmsSubmissionResult[] rs = endpoint.parseResponse(
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='1'>\n" + "        <message>\n" + "            <status>0</status>\n"
+                        + "            <to>not-a-number</to>\n" + "            <messageId>message-id-1</messageId>\n"
+                        + "            <remainingBalance>26.43133450</remainingBalance>\n"
+                        + "            <messagePrice>0.03330000</messagePrice>\n"
+                        + "            <network>12345</network>\n" + "            <WHATISTHIS></WHATISTHIS>\n"
+                        + "        </message>\n" + "    </messages>\n" + "</mt-submission-response>");
         assertEquals(SmsSubmissionResult.STATUS_OK, rs[0].getStatus());
     }
 
     @Test
     public void testParseResponseInvalidNumbers() throws Exception {
-        SmsSubmissionResult[] rs = endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                "<mt-submission-response>\n" +
-                "    <messages count='1'>\n" +
-                "        <message>\n" +
-                "            <status>0</status>\n" +
-                "            <to>not-a-number</to>\n" +
-                "            <messageId>message-id-1</messageId>\n" +
-                "            <remainingBalance>NOTANUMBER</remainingBalance>\n" +
-                "            <messagePrice>ALSONOTANUMBER</messagePrice>\n" +
-                "            <network>12345</network>\n" +
-                "        </message>\n" +
-                "    </messages>\n" +
-                "</mt-submission-response>");
+        SmsSubmissionResult[] rs = endpoint.parseResponse(
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='1'>\n" + "        <message>\n" + "            <status>0</status>\n"
+                        + "            <to>not-a-number</to>\n" + "            <messageId>message-id-1</messageId>\n"
+                        + "            <remainingBalance>NOTANUMBER</remainingBalance>\n"
+                        + "            <messagePrice>ALSONOTANUMBER</messagePrice>\n"
+                        + "            <network>12345</network>\n" + "        </message>\n" + "    </messages>\n"
+                        + "</mt-submission-response>");
         assertNull(rs[0].getRemainingBalance());
         assertNull(rs[0].getMessagePrice());
     }
 
     @Test
     public void testParseResponseStatusThrottled() throws Exception {
-        SmsSubmissionResult[] rs = endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                "<mt-submission-response>\n" +
-                "    <messages count='1'>\n" +
-                "        <message>\n" +
-                "            <status>1</status>\n" +
-                "        </message>\n" +
-                "    </messages>\n" +
-                "</mt-submission-response>");
+        SmsSubmissionResult[] rs = endpoint.parseResponse(
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='1'>\n" + "        <message>\n" + "            <status>1</status>\n"
+                        + "        </message>\n" + "    </messages>\n" + "</mt-submission-response>");
         assertEquals(SmsSubmissionResult.STATUS_THROTTLED, rs[0].getStatus());
         assertTrue(rs[0].getTemporaryError());
     }
 
     @Test
     public void testParseResponseStatusInternalError() throws Exception {
-        SmsSubmissionResult[] rs = endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                "<mt-submission-response>\n" +
-                "    <messages count='1'>\n" +
-                "        <message>\n" +
-                "            <status>5</status>\n" +
-                "        </message>\n" +
-                "    </messages>\n" +
-                "</mt-submission-response>");
+        SmsSubmissionResult[] rs = endpoint.parseResponse(
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='1'>\n" + "        <message>\n" + "            <status>5</status>\n"
+                        + "        </message>\n" + "    </messages>\n" + "</mt-submission-response>");
         assertEquals(SmsSubmissionResult.STATUS_INTERNAL_ERROR, rs[0].getStatus());
         assertTrue(rs[0].getTemporaryError());
     }
 
     @Test
     public void testParseResponseStatusTooManyBinds() throws Exception {
-        SmsSubmissionResult[] rs = endpoint.parseResponse("<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                "<mt-submission-response>\n" +
-                "    <messages count='1'>\n" +
-                "        <message>\n" +
-                "            <status>10</status>\n" +
-                "        </message>\n" +
-                "    </messages>\n" +
-                "</mt-submission-response>");
+        SmsSubmissionResult[] rs = endpoint.parseResponse(
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='1'>\n" + "        <message>\n" + "            <status>10</status>\n"
+                        + "        </message>\n" + "    </messages>\n" + "</mt-submission-response>");
         assertEquals(SmsSubmissionResult.STATUS_TOO_MANY_BINDS, rs[0].getStatus());
         assertTrue(rs[0].getTemporaryError());
     }
@@ -343,10 +288,7 @@ public class SendMessageEndpointTest {
 
     private static void assertContainsParam(List<NameValuePair> params, String key, String value) {
         NameValuePair item = new BasicNameValuePair(key, value);
-        assertTrue(
-                "" + params + " should contain " + item,
-                params.contains(item)
-        );
+        assertTrue("" + params + " should contain " + item, params.contains(item));
     }
 
     private static void assertMissingParam(List<NameValuePair> params, String key) {
@@ -365,20 +307,15 @@ public class SendMessageEndpointTest {
         AuthMethod tokenAuth = new TokenAuthMethod("abcd", "def");
 
         when(wrapper.getAuthCollection()).thenReturn(authCollection);
-        @SuppressWarnings("unchecked")
-        Set<Class> anySet = any(Set.class);
+        when(wrapper.getHttpConfig()).thenReturn(HttpConfig.defaultConfig());
+        @SuppressWarnings("unchecked") Set<Class> anySet = any(Set.class);
         when(authCollection.getAcceptableAuthMethod(anySet)).thenReturn(tokenAuth);
         when(wrapper.getHttpClient()).thenReturn(client);
-        when(client.execute(any(HttpUriRequest.class))).thenReturn(
-                TestUtils.makeJsonHttpResponse(200, "<?xml version='1.0' encoding='UTF-8' ?>\n" +
-                        "<mt-submission-response>\n" +
-                        "    <messages count='1'>\n" +
-                        "        <message>\n" +
-                        "            <status>10</status>\n" +
-                        "        </message>\n" +
-                        "    </messages>\n" +
-                        "</mt-submission-response>")
-        );
+        when(client.execute(any(HttpUriRequest.class))).thenReturn(TestUtils.makeJsonHttpResponse(200,
+                "<?xml version='1.0' encoding='UTF-8' ?>\n" + "<mt-submission-response>\n"
+                        + "    <messages count='1'>\n" + "        <message>\n" + "            <status>10</status>\n"
+                        + "        </message>\n" + "    </messages>\n" + "</mt-submission-response>"
+        ));
 
         ArgumentCaptor<HttpUriRequest> argument = ArgumentCaptor.forClass(HttpUriRequest.class);
 
@@ -390,8 +327,29 @@ public class SendMessageEndpointTest {
         if (argument.getValue() instanceof HttpEntityEnclosingRequest) {
             HttpEntity entity = ((HttpEntityEnclosingRequest) argument.getValue()).getEntity();
             assertNotNull(entity);
-            assertEquals("application/x-www-form-urlencoded; charset=UTF-8",
-                    entity.getContentType().getValue());
+            assertEquals("application/x-www-form-urlencoded; charset=UTF-8", entity.getContentType().getValue());
         }
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        Message message = new TextMessage("TestSender", "not-a-number", "Test", true);
+
+        RequestBuilder builder = endpoint.makeRequest(message);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://rest.nexmo.com/sms/xml",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        SendMessageEndpoint endpoint = new SendMessageEndpoint(wrapper);
+        Message message = new TextMessage("TestSender", "not-a-number", "Test", true);
+
+        RequestBuilder builder = endpoint.makeRequest(message);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/sms/xml", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/sms/SmsSingleSearchEndpointTest.java
+++ b/src/test/java/com/nexmo/client/sms/SmsSingleSearchEndpointTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.sms;
+
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
+import org.apache.http.client.methods.RequestBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SmsSingleSearchEndpointTest {
+    private SmsSingleSearchEndpoint endpoint;
+
+    @Before
+    public void setUp() throws Exception {
+        this.endpoint = new SmsSingleSearchEndpoint(new HttpWrapper());
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        RequestBuilder builder = endpoint.makeRequest("id");
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://rest.nexmo.com/search/message?id=id",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        SmsSingleSearchEndpoint endpoint = new SmsSingleSearchEndpoint(wrapper);
+
+        RequestBuilder builder = endpoint.makeRequest("id");
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://example.com/search/message?id=id", builder.build().getURI().toString());
+    }
+}

--- a/src/test/java/com/nexmo/client/verify/SearchMethodTest.java
+++ b/src/test/java/com/nexmo/client/verify/SearchMethodTest.java
@@ -23,59 +23,37 @@ package com.nexmo.client.verify;
 
 import com.nexmo.client.HttpConfig;
 import com.nexmo.client.HttpWrapper;
-import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.RequestBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
 
-public class CheckMethodTest extends MethodTest<CheckMethod> {
+public class SearchMethodTest {
+    private SearchMethod method;
+
     @Before
-    public void setUp() {
-        method = new CheckMethod(new HttpWrapper());
-    }
-
-    @Test
-    public void testConstructVerifyParamsWithoutIp() throws Exception {
-        CheckRequest checkRequest = new CheckRequest("request-id", "code");
-        RequestBuilder request = method.makeRequest(checkRequest);
-        List<NameValuePair> params = request.getParameters();
-
-        assertContainsParam(params, "request_id", "request-id");
-        assertContainsParam(params, "code", "code");
-        assertParamMissing(params, "ip_address");
-    }
-
-    @Test
-    public void testConstructVerifyParamsWithIp() throws Exception {
-        CheckRequest checkRequest = new CheckRequest("request-id", "code", "ip-address");
-        RequestBuilder request = method.makeRequest(checkRequest);
-        List<NameValuePair> params = request.getParameters();
-
-        assertContainsParam(params, "request_id", "request-id");
-        assertContainsParam(params, "code", "code");
-        assertContainsParam(params, "ip_address", "ip-address");
+    public void setUp() throws Exception {
+        this.method = new SearchMethod(new HttpWrapper());
     }
 
     @Test
     public void testDefaultUri() throws Exception {
-        CheckRequest request = new CheckRequest("request-id", "code");
+        SearchRequest request = new SearchRequest("request-id");
+
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://api.nexmo.com/verify/check/json", builder.build().getURI().toString());
+        assertEquals("https://api.nexmo.com/verify/search/json", builder.build().getURI().toString());
     }
 
     @Test
     public void testCustomUri() throws Exception {
         HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
-        CheckMethod method = new CheckMethod(wrapper);
-        CheckRequest request = new CheckRequest("request-id", "code");
+        SearchMethod method = new SearchMethod(wrapper);
+        SearchRequest request = new SearchRequest("request-id");
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://example.com/verify/check/json", builder.build().getURI().toString());
+        assertEquals("https://example.com/verify/search/json", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/verify/VerifyMethodTest.java
+++ b/src/test/java/com/nexmo/client/verify/VerifyMethodTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.verify;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.RequestBuilder;
 import org.junit.Before;
@@ -29,11 +31,13 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Locale;
 
+import static org.junit.Assert.assertEquals;
+
 public class VerifyMethodTest extends MethodTest<VerifyMethod> {
 
     @Before
     public void setUp() {
-        method = new VerifyMethod(null);
+        method = new VerifyMethod(new HttpWrapper());
     }
 
     @Test
@@ -43,7 +47,8 @@ public class VerifyMethodTest extends MethodTest<VerifyMethod> {
                 "Your friend",
                 4,
                 new Locale("en", "GB"),
-                VerifyRequest.LineType.MOBILE);
+                VerifyRequest.LineType.MOBILE
+        );
 
         RequestBuilder request = method.makeRequest(verifyRequest);
         List<NameValuePair> params = request.getParameters();
@@ -96,6 +101,39 @@ public class VerifyMethodTest extends MethodTest<VerifyMethod> {
         assertContainsParam(params, "country", "ZZ");
         assertContainsParam(params, "pin_expiry", "60");
         assertContainsParam(params, "next_event_wait", "90");
+    }
 
+    @Test
+    public void testDefaultUri() throws Exception {
+        VerifyRequest request = new VerifyRequest("4477990090090",
+                "Brand.com",
+                "Your friend",
+                4,
+                new Locale("en", "GB"),
+                VerifyRequest.LineType.MOBILE
+        );
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/verify/json",
+                builder.build().getURI().toString()
+        );
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        VerifyMethod method = new VerifyMethod(wrapper);
+        VerifyRequest request = new VerifyRequest("4477990090090",
+                "Brand.com",
+                "Your friend",
+                4,
+                new Locale("en", "GB"),
+                VerifyRequest.LineType.MOBILE
+        );
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/verify/json", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/verify/endpoints/ControlEndpointTest.java
+++ b/src/test/java/com/nexmo/client/verify/endpoints/ControlEndpointTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.verify.endpoints;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
@@ -44,7 +46,7 @@ public class ControlEndpointTest {
 
     @Before
     public void setUp() throws Exception {
-        this.endpoint = new ControlEndpoint(null);
+        this.endpoint = new ControlEndpoint(new HttpWrapper());
     }
 
     @Test
@@ -55,12 +57,11 @@ public class ControlEndpointTest {
 
     @Test
     public void testMakeRequest() throws Exception {
-        RequestBuilder builder = this.endpoint.makeRequest(new ControlRequest(
-                "request-id", VerifyControlCommand.CANCEL
+        RequestBuilder builder = this.endpoint.makeRequest(new ControlRequest("request-id",
+                VerifyControlCommand.CANCEL
         ));
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://api.nexmo.com/verify/control/json", builder.build()
-                .getURI().toString());
+        assertEquals("https://api.nexmo.com/verify/control/json", builder.build().getURI().toString());
 
         Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
         assertEquals("request-id", params.get("request_id"));
@@ -69,10 +70,9 @@ public class ControlEndpointTest {
 
     @Test
     public void testParseResponse() throws Exception {
-        HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
-                "  \"status\":\"0\",\n" +
-                "  \"command\":\"cancel\"\n" +
-                "}");
+        HttpResponse stub = TestUtils.makeJsonHttpResponse(200,
+                "{\n" + "  \"status\":\"0\",\n" + "  \"command\":\"cancel\"\n" + "}"
+        );
         ControlResponse response = this.endpoint.parseResponse(stub);
         assertEquals("0", response.getStatus());
         assertEquals(VerifyControlCommand.CANCEL, response.getCommand());
@@ -80,17 +80,35 @@ public class ControlEndpointTest {
 
     @Test
     public void testParseErrorResponse() throws Exception {
-        HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
-                "    \"error_text\": \"Missing username\",\n" +
-                "    \"status\": \"2\"\n" +
-                "}");
+        HttpResponse stub = TestUtils.makeJsonHttpResponse(200,
+                "{\n" + "    \"error_text\": \"Missing username\",\n" + "    \"status\": \"2\"\n" + "}"
+        );
         try {
             ControlResponse response = this.endpoint.parseResponse(stub);
             fail("Parsing an error response should throw an exception.");
-        } catch(VerifyException exc){
-                assertEquals("2", exc.getStatus());
-                assertEquals("Missing username", exc.getErrorText());
-            }
-
+        } catch (VerifyException exc) {
+            assertEquals("2", exc.getStatus());
+            assertEquals("Missing username", exc.getErrorText());
         }
     }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        ControlRequest request = new ControlRequest("request-id", VerifyControlCommand.CANCEL);
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://api.nexmo.com/verify/control/json", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        ControlEndpoint endpoint = new ControlEndpoint(wrapper);
+        ControlRequest request = new ControlRequest("request-id", VerifyControlCommand.CANCEL);
+
+        RequestBuilder builder = endpoint.makeRequest(request);
+        assertEquals("POST", builder.getMethod());
+        assertEquals("https://example.com/verify/control/json", builder.build().getURI().toString());
+    }
+}

--- a/src/test/java/com/nexmo/client/voice/endpoints/CreateCallMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/CreateCallMethodTest.java
@@ -152,6 +152,6 @@ public class CreateCallMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://example.com/v1/calls", builder.build().getURI().toString());
+        assertEquals("https://example.com/calls", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/ListCallsMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ListCallsMethodTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.voice.endpoints;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoUnexpectedException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import com.nexmo.client.voice.CallInfoPage;
@@ -51,14 +53,12 @@ public class ListCallsMethodTest {
 
     @Before
     public void setUp() throws Exception {
-        method = new ListCallsMethod(null);
+        method = new ListCallsMethod(new HttpWrapper());
     }
 
     @Test
     public void getAcceptableAuthMethods() throws Exception {
-        assertArrayEquals(
-                new Class[]{JWTAuthMethod.class},
-                method.getAcceptableAuthMethods());
+        assertArrayEquals(new Class[]{JWTAuthMethod.class}, method.getAcceptableAuthMethods());
     }
 
     @Test
@@ -79,80 +79,42 @@ public class ListCallsMethodTest {
 
     @Test
     public void parseResponse() throws Exception {
-        HttpResponse stubResponse = new BasicHttpResponse(
-                new BasicStatusLine(new ProtocolVersion("1.1", 1, 1), 200, "OK")
-        );
+        HttpResponse stubResponse = new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("1.1", 1, 1),
+                200,
+                "OK"
+        ));
 
-        String json = "{\n" +
-                "  \"page_size\": 10,\n" +
-                "  \"record_index\": 0,\n" +
-                "  \"count\": 2,\n" +
-                "  \"_embedded\": {\n" +
-                "    \"calls\": [\n" +
-                "      {\n" +
-                "        \"uuid\": \"93137ee3-580e-45f7-a61a-e0b5716000ef\",\n" +
-                "        \"status\": \"completed\",\n" +
-                "        \"direction\": \"outbound\",\n" +
-                "        \"rate\": \"0.02400000\",\n" +
-                "        \"price\": \"0.00280000\",\n" +
-                "        \"duration\": \"7\",\n" +
-                "        \"network\": \"23410\",\n" +
-                "        \"conversation_uuid\": \"aa17bd11-c895-4225-840d-30dc38c31e50\",\n" +
-                "        \"start_time\": \"2017-01-13T13:55:02.000Z\",\n" +
-                "        \"end_time\": \"2017-01-13T13:55:09.000Z\",\n" +
-                "        \"to\": {\n" +
-                "          \"type\": \"phone\",\n" +
-                "          \"number\": \"447700900104\"\n" +
-                "        },\n" +
-                "        \"from\": {\n" +
-                "          \"type\": \"phone\",\n" +
-                "          \"number\": \"447700900105\"\n" +
-                "        },\n" +
-                "        \"_links\": {\n" +
-                "          \"self\": {\n" +
-                "            \"href\": \"/v1/calls/93137ee3-580e-45f7-a61a-e0b5716000ef\"\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"uuid\": \"105e02df-940a-466c-b28b-51ae015a9166\",\n" +
-                "        \"status\": \"completed\",\n" +
-                "        \"direction\": \"outbound\",\n" +
-                "        \"rate\": \"0.02400000\",\n" +
-                "        \"price\": \"0.00280000\",\n" +
-                "        \"duration\": \"7\",\n" +
-                "        \"network\": \"23410\",\n" +
-                "        \"conversation_uuid\": \"1467b438-f5a8-4937-9a65-e1f946a2f664\",\n" +
-                "        \"start_time\": \"2017-01-11T15:03:46.000Z\",\n" +
-                "        \"end_time\": \"2017-01-11T15:03:53.000Z\",\n" +
-                "        \"to\": {\n" +
-                "          \"type\": \"phone\",\n" +
-                "          \"number\": \"447700900104\"\n" +
-                "        },\n" +
-                "        \"from\": {\n" +
-                "          \"type\": \"phone\",\n" +
-                "          \"number\": \"447700900105\"\n" +
-                "        },\n" +
-                "        \"_links\": {\n" +
-                "          \"self\": {\n" +
-                "            \"href\": \"/v1/calls/105e02df-940a-466c-b28b-51ae015a9166\"\n" +
-                "          }\n" +
-                "        }\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  },\n" +
-                "  \"_links\": {\n" +
-                "    \"self\": {\n" +
-                "      \"href\": \"/v1/calls?page_size=10&record_index=0\"\n" +
-                "    },\n" +
-                "    \"first\": {\n" +
-                "      \"href\": \"/v1/calls?page_size=10\"\n" +
-                "    },\n" +
-                "    \"last\": {\n" +
-                "      \"href\": \"/v1/calls?page_size=10\"\n" +
-                "    }\n" +
-                "  }\n" +
-                "}\n";
+        String json = "{\n" + "  \"page_size\": 10,\n" + "  \"record_index\": 0,\n" + "  \"count\": 2,\n"
+                + "  \"_embedded\": {\n" + "    \"calls\": [\n" + "      {\n"
+                + "        \"uuid\": \"93137ee3-580e-45f7-a61a-e0b5716000ef\",\n"
+                + "        \"status\": \"completed\",\n" + "        \"direction\": \"outbound\",\n"
+                + "        \"rate\": \"0.02400000\",\n" + "        \"price\": \"0.00280000\",\n"
+                + "        \"duration\": \"7\",\n" + "        \"network\": \"23410\",\n"
+                + "        \"conversation_uuid\": \"aa17bd11-c895-4225-840d-30dc38c31e50\",\n"
+                + "        \"start_time\": \"2017-01-13T13:55:02.000Z\",\n"
+                + "        \"end_time\": \"2017-01-13T13:55:09.000Z\",\n" + "        \"to\": {\n"
+                + "          \"type\": \"phone\",\n" + "          \"number\": \"447700900104\"\n" + "        },\n"
+                + "        \"from\": {\n" + "          \"type\": \"phone\",\n"
+                + "          \"number\": \"447700900105\"\n" + "        },\n" + "        \"_links\": {\n"
+                + "          \"self\": {\n"
+                + "            \"href\": \"/v1/calls/93137ee3-580e-45f7-a61a-e0b5716000ef\"\n" + "          }\n"
+                + "        }\n" + "      },\n" + "      {\n"
+                + "        \"uuid\": \"105e02df-940a-466c-b28b-51ae015a9166\",\n"
+                + "        \"status\": \"completed\",\n" + "        \"direction\": \"outbound\",\n"
+                + "        \"rate\": \"0.02400000\",\n" + "        \"price\": \"0.00280000\",\n"
+                + "        \"duration\": \"7\",\n" + "        \"network\": \"23410\",\n"
+                + "        \"conversation_uuid\": \"1467b438-f5a8-4937-9a65-e1f946a2f664\",\n"
+                + "        \"start_time\": \"2017-01-11T15:03:46.000Z\",\n"
+                + "        \"end_time\": \"2017-01-11T15:03:53.000Z\",\n" + "        \"to\": {\n"
+                + "          \"type\": \"phone\",\n" + "          \"number\": \"447700900104\"\n" + "        },\n"
+                + "        \"from\": {\n" + "          \"type\": \"phone\",\n"
+                + "          \"number\": \"447700900105\"\n" + "        },\n" + "        \"_links\": {\n"
+                + "          \"self\": {\n"
+                + "            \"href\": \"/v1/calls/105e02df-940a-466c-b28b-51ae015a9166\"\n" + "          }\n"
+                + "        }\n" + "      }\n" + "    ]\n" + "  },\n" + "  \"_links\": {\n" + "    \"self\": {\n"
+                + "      \"href\": \"/v1/calls?page_size=10&record_index=0\"\n" + "    },\n" + "    \"first\": {\n"
+                + "      \"href\": \"/v1/calls?page_size=10\"\n" + "    },\n" + "    \"last\": {\n"
+                + "      \"href\": \"/v1/calls?page_size=10\"\n" + "    }\n" + "  }\n" + "}\n";
         InputStream jsonStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
         BasicHttpEntity entity = new BasicHttpEntity();
         entity.setContent(jsonStream);
@@ -184,5 +146,27 @@ public class ListCallsMethodTest {
     @Test
     public void testRequestThrottleResponse() throws Exception {
         test429(new ListCallsMethod(null));
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        CallsFilter filter = new CallsFilter();
+        filter.setPageSize(3);
+
+        RequestBuilder builder = method.makeRequest(filter);
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/calls?page_size=3", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        ListCallsMethod method = new ListCallsMethod(wrapper);
+        CallsFilter filter = new CallsFilter();
+        filter.setPageSize(3);
+
+        RequestBuilder builder = method.makeRequest(filter);
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://example.com/v1/calls?page_size=3", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/ListCallsMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ListCallsMethodTest.java
@@ -167,6 +167,6 @@ public class ListCallsMethodTest {
 
         RequestBuilder builder = method.makeRequest(filter);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/v1/calls?page_size=3", builder.build().getURI().toString());
+        assertEquals("https://example.com/calls?page_size=3", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/ReadCallMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ReadCallMethodTest.java
@@ -101,6 +101,6 @@ public class ReadCallMethodTest {
 
         RequestBuilder builder = method.makeRequest("call-id");
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/v1/calls/call-id", builder.build().getURI().toString());
+        assertEquals("https://example.com/calls/call-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/ReadCallMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ReadCallMethodTest.java
@@ -21,6 +21,8 @@
  */
 package com.nexmo.client.voice.endpoints;
 
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.TestUtils;
 import com.nexmo.client.auth.JWTAuthMethod;
 import com.nexmo.client.voice.CallInfo;
@@ -38,7 +40,7 @@ public class ReadCallMethodTest {
 
     @Before
     public void setUp() throws Exception {
-        this.method = new ReadCallMethod(null);
+        this.method = new ReadCallMethod(new HttpWrapper());
     }
 
     @Test
@@ -55,31 +57,20 @@ public class ReadCallMethodTest {
     @Test
     public void parseResponse() throws Exception {
         HttpResponse stubResponse = TestUtils.makeJsonHttpResponse(200,
-                "      {\n" +
-                        "        \"uuid\": \"93137ee3-580e-45f7-a61a-e0b5716000ef\",\n" +
-                        "        \"status\": \"completed\",\n" +
-                        "        \"direction\": \"outbound\",\n" +
-                        "        \"rate\": \"0.02400000\",\n" +
-                        "        \"price\": \"0.00280000\",\n" +
-                        "        \"duration\": \"7\",\n" +
-                        "        \"network\": \"23410\",\n" +
-                        "        \"conversation_uuid\": \"aa17bd11-c895-4225-840d-30dc38c31e50\",\n" +
-                        "        \"start_time\": \"2017-01-13T13:55:02.000Z\",\n" +
-                        "        \"end_time\": \"2017-01-13T13:55:09.000Z\",\n" +
-                        "        \"to\": {\n" +
-                        "          \"type\": \"phone\",\n" +
-                        "          \"number\": \"447700900104\"\n" +
-                        "        },\n" +
-                        "        \"from\": {\n" +
-                        "          \"type\": \"phone\",\n" +
-                        "          \"number\": \"447700900105\"\n" +
-                        "        },\n" +
-                        "        \"_links\": {\n" +
-                        "          \"self\": {\n" +
-                        "            \"href\": \"/v1/calls/93137ee3-580e-45f7-a61a-e0b5716000ef\"\n" +
-                        "          }\n" +
-                        "        }\n" +
-                        "      }\n");
+                "      {\n" + "        \"uuid\": \"93137ee3-580e-45f7-a61a-e0b5716000ef\",\n"
+                        + "        \"status\": \"completed\",\n" + "        \"direction\": \"outbound\",\n"
+                        + "        \"rate\": \"0.02400000\",\n" + "        \"price\": \"0.00280000\",\n"
+                        + "        \"duration\": \"7\",\n" + "        \"network\": \"23410\",\n"
+                        + "        \"conversation_uuid\": \"aa17bd11-c895-4225-840d-30dc38c31e50\",\n"
+                        + "        \"start_time\": \"2017-01-13T13:55:02.000Z\",\n"
+                        + "        \"end_time\": \"2017-01-13T13:55:09.000Z\",\n" + "        \"to\": {\n"
+                        + "          \"type\": \"phone\",\n" + "          \"number\": \"447700900104\"\n"
+                        + "        },\n" + "        \"from\": {\n" + "          \"type\": \"phone\",\n"
+                        + "          \"number\": \"447700900105\"\n" + "        },\n" + "        \"_links\": {\n"
+                        + "          \"self\": {\n"
+                        + "            \"href\": \"/v1/calls/93137ee3-580e-45f7-a61a-e0b5716000ef\"\n" + "          }\n"
+                        + "        }\n" + "      }\n"
+        );
         CallInfo record = method.parseResponse(stubResponse);
         assertEquals("93137ee3-580e-45f7-a61a-e0b5716000ef", record.getUuid());
     }
@@ -94,5 +85,22 @@ public class ReadCallMethodTest {
     @Test
     public void testRequestThrottleResponse() throws Exception {
         test429(new ReadCallMethod(null));
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        RequestBuilder builder = method.makeRequest("call-id");
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/calls/call-id", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        ReadCallMethod method = new ReadCallMethod(wrapper);
+
+        RequestBuilder builder = method.makeRequest("call-id");
+        assertEquals("GET", builder.getMethod());
+        assertEquals("https://example.com/v1/calls/call-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/StartStreamMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/StartStreamMethodTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.voice.endpoints;
+
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.voice.StreamRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StartStreamMethodTest {
+    private StartStreamMethod method;
+
+    @Before
+    public void setUp() throws Exception {
+        this.method = new StartStreamMethod(new HttpWrapper());
+    }
+
+    @Test
+    public void testLegacyCustomUri() throws Exception {
+        StreamRequest request = new StreamRequest("uuid", "stream-url", 0);
+        method.setUri("https://api.example.org/");
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("PUT", builder.getMethod());
+        assertEquals("https://api.example.org/uuid/stream", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        StreamRequest request = new StreamRequest("uuid", "stream-url", 0);
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("PUT", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/calls/uuid/stream", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        StartStreamMethod method = new StartStreamMethod(wrapper);
+        StreamRequest request = new StreamRequest("uuid", "stream-url", 0);
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("PUT", builder.getMethod());
+        assertEquals("https://example.com/v1/calls/uuid/stream", builder.build().getURI().toString());
+    }
+}

--- a/src/test/java/com/nexmo/client/voice/endpoints/StartStreamMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/StartStreamMethodTest.java
@@ -63,6 +63,6 @@ public class StartStreamMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("PUT", builder.getMethod());
-        assertEquals("https://example.com/v1/calls/uuid/stream", builder.build().getURI().toString());
+        assertEquals("https://example.com/calls/uuid/stream", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/StartTalkMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/StartTalkMethodTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.voice.endpoints;
+
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.voice.TalkRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StartTalkMethodTest {
+    private StartTalkMethod method;
+
+    @Before
+    public void setUp() throws Exception {
+        this.method = new StartTalkMethod(new HttpWrapper());
+    }
+
+    @Test
+    public void testLegacyCustomUri() throws Exception {
+        TalkRequest request = new TalkRequest("uuid", "text", 0);
+        method.setUri("https://api.example.org/");
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("PUT", builder.getMethod());
+        assertEquals("https://api.example.org/uuid/talk", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        TalkRequest request = new TalkRequest("uuid", "text", 0);
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("PUT", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/calls/uuid/talk", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        StartTalkMethod method = new StartTalkMethod(wrapper);
+        TalkRequest request = new TalkRequest("uuid", "text", 0);
+
+        RequestBuilder builder = method.makeRequest(request);
+        assertEquals("PUT", builder.getMethod());
+        assertEquals("https://example.com/v1/calls/uuid/talk", builder.build().getURI().toString());
+    }
+}

--- a/src/test/java/com/nexmo/client/voice/endpoints/StartTalkMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/StartTalkMethodTest.java
@@ -63,6 +63,6 @@ public class StartTalkMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("PUT", builder.getMethod());
-        assertEquals("https://example.com/v1/calls/uuid/talk", builder.build().getURI().toString());
+        assertEquals("https://example.com/calls/uuid/talk", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/StopStreamMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/StopStreamMethodTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.voice.endpoints;
+
+import com.nexmo.client.HttpConfig;
+import com.nexmo.client.HttpWrapper;
+import org.apache.http.client.methods.RequestBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StopStreamMethodTest {
+    private StopStreamMethod method;
+
+    @Before
+    public void setUp() throws Exception {
+        this.method = new StopStreamMethod(new HttpWrapper());
+    }
+
+    @Test
+    public void testLegacyCustomUri() throws Exception {
+        method.setUri("https://api.example.org/");
+        RequestBuilder builder = method.makeRequest("uuid");
+        assertEquals("DELETE", builder.getMethod());
+        assertEquals("https://api.example.org/uuid/stream", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testDefaultUri() throws Exception {
+        RequestBuilder builder = method.makeRequest("uuid");
+        assertEquals("DELETE", builder.getMethod());
+        assertEquals("https://api.nexmo.com/v1/calls/uuid/stream", builder.build().getURI().toString());
+    }
+
+    @Test
+    public void testCustomUri() throws Exception {
+        HttpWrapper wrapper = new HttpWrapper(new HttpConfig.Builder().baseUri("https://example.com").build());
+        StopStreamMethod method = new StopStreamMethod(wrapper);
+
+        RequestBuilder builder = method.makeRequest("uuid");
+        assertEquals("DELETE", builder.getMethod());
+        assertEquals("https://example.com/v1/calls/uuid/stream", builder.build().getURI().toString());
+    }
+}

--- a/src/test/java/com/nexmo/client/voice/endpoints/StopStreamMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/StopStreamMethodTest.java
@@ -59,6 +59,6 @@ public class StopStreamMethodTest {
 
         RequestBuilder builder = method.makeRequest("uuid");
         assertEquals("DELETE", builder.getMethod());
-        assertEquals("https://example.com/v1/calls/uuid/stream", builder.build().getURI().toString());
+        assertEquals("https://example.com/calls/uuid/stream", builder.build().getURI().toString());
     }
 }


### PR DESCRIPTION
Allow users to customize the base uri to differ from the defaults (https://rest.nexmo.com, https://api.nexmo.com, https://sns.nexmo.com).

A new configuration class has been added called `HttpConfig` which is used in the various `Method` and `Endpoints` to determine the base uri.

## Usage

To override all three:
```java
HttpConfig httpConfig = new HttpConfig.Builder().baseUri("http://example.com").build(); 
NexmoClient client = new NexmoClient(httpConfig, new TokenAuthMethod(API_KEY, API_SECRET));
```

To override a combination:

```java
HttpConfig httpConfig = new HttpConfig.Builder()
                .apiBaseUri("https://api.example.com")
                .restBaseUri("https://rest.example.com")
                .build();

NexmoClient client = new NexmoClient(httpConfig, new TokenAuthMethod(API_KEY, API_SECRET));
```

Not passing an `HttpConfig` object to `NexmoClient` on instantiation will use the default base uri for each endpoint.
## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
