### PR TITLE
Add NCCO Class for Connecting to WebSocket Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Development]
 ### Added
 - Updated `VoiceName` enum with missing voices.
+- Added `ConnectWebSocketNcco` to handle connecting to WebSocket endpoints similar to `ConnectNcco` to maintain backwards compatibility.
 
 ## [3.8.0] - 2018-09-19
 ### Added

--- a/src/main/java/com/nexmo/client/voice/ncco/ConnectWebSocketNcco.java
+++ b/src/main/java/com/nexmo/client/voice/ncco/ConnectWebSocketNcco.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.voice.ncco;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nexmo.client.voice.MachineDetection;
+
+import java.util.Map;
+
+/**
+ * Connect action for connecting to WebSocket endpoints.
+ * <p>
+ * Note: Functionality for this will significantly change in the next major version release.
+ *
+ * This was implemented to emulate {@link ConnectNcco} as it is locked to a Phone endpoint while still maintaining backwards compatibility.
+ */
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConnectWebSocketNcco implements Ncco {
+    private static final String ACTION = "connect";
+
+    private WebSocketEndpoint[] endpoint;
+    private String from = null;
+    private Integer timeout = null;
+    private Integer limit = null;
+    private MachineDetection machineDetection = null;
+    private String[] eventUrl = null;
+    private String eventMethod = null;
+
+    public ConnectWebSocketNcco(@JsonProperty("endpoint") WebSocketEndpoint[] endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public ConnectWebSocketNcco(WebSocketEndpoint endpoint) {
+        this(new WebSocketEndpoint[]{endpoint});
+    }
+
+    public ConnectWebSocketNcco(String uri, String contentType, Map<String, String> headers) {
+        this(new WebSocketEndpoint(uri, contentType, headers));
+    }
+
+    public ConnectWebSocketNcco(String uri, String contentType) {
+        this(new WebSocketEndpoint(uri, contentType));
+    }
+
+    public WebSocketEndpoint[] getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(WebSocketEndpoint endpoint) {
+        setEndpoint(new WebSocketEndpoint[]{endpoint});
+    }
+
+    @JsonProperty("endpoint")
+    public void setEndpoint(WebSocketEndpoint[] endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public Integer getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Integer timeout) {
+        this.timeout = timeout;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Integer limit) {
+        this.limit = limit;
+    }
+
+    public MachineDetection getMachineDetection() {
+        return machineDetection;
+    }
+
+    public void setMachineDetection(MachineDetection machineDetection) {
+        this.machineDetection = machineDetection;
+    }
+
+    public String[] getEventUrl() {
+        return eventUrl;
+    }
+
+    public void setEventUrl(String eventUrl) {
+        setEventUrl(new String[]{eventUrl});
+    }
+
+    @JsonProperty("eventUrl")
+    public void setEventUrl(String[] eventUrl) {
+        this.eventUrl = eventUrl;
+    }
+
+    public String getEventMethod() {
+        return eventMethod;
+    }
+
+    public void setEventMethod(String eventMethod) {
+        this.eventMethod = eventMethod;
+    }
+
+    @Override
+    public String getAction() {
+        return ACTION;
+    }
+
+    @Override
+    public String toJson() {
+        return NccoSerializer.getInstance().serializeNcco(this);
+    }
+}

--- a/src/main/java/com/nexmo/client/voice/ncco/WebSocketEndpoint.java
+++ b/src/main/java/com/nexmo/client/voice/ncco/WebSocketEndpoint.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.voice.ncco;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+public class WebSocketEndpoint {
+    private static final String TYPE = "websocket";
+
+    private String uri;
+    private String contentType;
+    private Map<String, String> headers;
+
+    public WebSocketEndpoint(String uri, String contentType) {
+        this.uri = uri;
+        this.contentType = contentType;
+    }
+
+    public WebSocketEndpoint(String uri, String contentType, Map<String, String> headers) {
+        this(uri, contentType);
+        this.headers = headers;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    @JsonProperty("content-type")
+    public String getContentType() {
+        return contentType;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public String getType() {
+        return TYPE;
+    }
+
+    public String toLog() {
+        return "uri=" + uri + " content-type=" + contentType;
+    }
+}

--- a/src/test/java/com/nexmo/client/voice/ncco/ConnectWebSocketNccoTest.java
+++ b/src/test/java/com/nexmo/client/voice/ncco/ConnectWebSocketNccoTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2011-2018 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client.voice.ncco;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConnectWebSocketNccoTest {
+
+    @Test
+    public void getAction() throws Exception {
+        ConnectWebSocketNcco ncco = new ConnectWebSocketNcco(new WebSocketEndpoint("wss://example.com",
+                "content-type"
+        ));
+        assertEquals("connect", ncco.getAction());
+    }
+
+    @Test
+    public void testToJsonWebSocketConstructor() throws Exception {
+        assertEquals(
+                "{\"endpoint\":[{\"uri\":\"wss://example.com\",\"type\":\"websocket\",\"content-type\":\"content-type\"}],\"action\":\"connect\"}",
+                new ConnectWebSocketNcco(new WebSocketEndpoint("wss://example.com", "content-type")).toJson()
+        );
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("key", "value");
+        headers.put("key2", "value2");
+
+        assertEquals(
+                "{\"endpoint\":[{\"uri\":\"wss://example.com\",\"headers\":{\"key2\":\"value2\",\"key\":\"value\"},\"type\":\"websocket\",\"content-type\":\"content-type\"}],\"action\":\"connect\"}",
+                new ConnectWebSocketNcco(new WebSocketEndpoint("wss://example.com", "content-type", headers)).toJson()
+        );
+    }
+
+    @Test
+    public void testToJsonValueConstructors() throws Exception {
+        assertEquals(
+                "{\"endpoint\":[{\"uri\":\"wss://example.com\",\"type\":\"websocket\",\"content-type\":\"content-type\"}],\"action\":\"connect\"}",
+                new ConnectWebSocketNcco("wss://example.com", "content-type").toJson()
+        );
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("key", "value");
+        headers.put("key2", "value2");
+
+        assertEquals(
+                "{\"endpoint\":[{\"uri\":\"wss://example.com\",\"headers\":{\"key2\":\"value2\",\"key\":\"value\"},\"type\":\"websocket\",\"content-type\":\"content-type\"}],\"action\":\"connect\"}",
+                new ConnectWebSocketNcco("wss://example.com", "content-type", headers).toJson()
+        );
+    }
+}
+


### PR DESCRIPTION
This will _significantly_ change in the 4.0.0 release. However, I still think it's important to provide this functionality in a backwards compatible way.

It was not a simple matter of changing `ConnectNcco` to accept an `Endpoint` instead of a `PhoneEndpoint` and keep compatibility. A new class `ConnectWebSocketNcco` was created to facilitate this.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
