### PR TITLE
Explicitly Define Voice Name Display Values in VoiceName Enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Updated `VoiceName` enum with missing voices.
 - Added `ConnectWebSocketNcco` to handle connecting to WebSocket endpoints similar to `ConnectNcco` to maintain backwards compatibility.
+- Added `getDisplayName` method to `VoiceName` to represent the name that is used in serialization.
 
 ## [3.8.0] - 2018-09-19
 ### Added

--- a/src/main/java/com/nexmo/client/voice/VoiceName.java
+++ b/src/main/java/com/nexmo/client/voice/VoiceName.java
@@ -23,7 +23,6 @@ package com.nexmo.client.voice;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,92 +32,92 @@ import java.util.Map;
  */
 
 public enum VoiceName {
-    SALLI,
-    JOEY,
-    NAJA,
-    MADS,
-    MARLENE,
-    HANS,
-    NICOLE,
-    RUSSELL,
-    AMY,
-    BRIAN,
-    EMMA,
-    GWYNETH,
-    GERAINT,
-    RAVEENA,
-    CHIPMUNK,
-    ERIC,
-    IVY,
-    JENNIFER,
-    JUSTIN,
-    KENDRA,
-    KIMBERLY,
-    CONCHITA,
-    ENRIQUE,
-    PENELOPE,
-    MIGUEL,
-    CHANTAL,
-    CELINE,
-    MATHIEU,
-    DORA,
-    KARL,
-    CARLA,
-    GIORGIO,
-    LIV,
-    LOTTE,
-    RUBEN,
-    AGNIESZKA,
-    JACEK,
-    EWA,
-    JAN,
-    MAJA,
-    VITORIA,
-    RICARDO,
-    CRISTIANO,
-    INES,
-    CARMEN,
-    MAXIM,
-    TATYANA,
-    ASTRID,
-    FILIZ,
-    MIZUKI,
-    SEOYEON,
-    LAILA,
-    MAGED,
-    TARIK,
-    DAMAYANTI,
-    MIREN,
-//    SIN-JI,
-    JORDI,
-    MONTSERRAT,
-    IVETA,
-    ZUZANA,
-    TESSA,
-    SATU,
-    MELINA,
-    NIKOS,
-    CARMIT,
-    LEKHA,
-    MARISKA,
-    SORA,
-//    TIAN-TIAN,
-//    MEI-JIA,
-    NORA,
-    HENRIK,
-    LUCIANA,
-    FELIPE,
-    CATARINA,
-    JOANA,
-    IOANA,
-    LAURA,
-    ALVA,
-    OSKAR,
-    KANYA,
-    CEM,
-    YELDA,
-    EMPAR,
-    UNKNOWN;
+    SALLI("Salli"),
+    JOEY("Joey"),
+    NAJA("Naja"),
+    MADS("Mads"),
+    MARLENE("Marlene"),
+    HANS("Hans"),
+    NICOLE("Nicole"),
+    RUSSELL("Russell"),
+    AMY("Amy"),
+    BRIAN("Brian"),
+    EMMA("Emma"),
+    GWYNETH("Gwyneth"),
+    GERAINT("Geraint"),
+    RAVEENA("Raveena"),
+    CHIPMUNK("Chipmunk"),
+    ERIC("Eric"),
+    IVY("Ivy"),
+    JENNIFER("Jennifer"),
+    JUSTIN("Justin"),
+    KENDRA("Kendra"),
+    KIMBERLY("Kimberly"),
+    CONCHITA("Conchita"),
+    ENRIQUE("Enrique"),
+    PENELOPE("Penelope"),
+    MIGUEL("Miguel"),
+    CHANTAL("Chantal"),
+    CELINE("Celine"),
+    MATHIEU("Mathieu"),
+    DORA("Dora"),
+    KARL("Karl"),
+    CARLA("Carla"),
+    GIORGIO("Giorgio"),
+    LIV("Liv"),
+    LOTTE("Lotte"),
+    RUBEN("Ruben"),
+    AGNIESZKA("Agnieszka"),
+    JACEK("Jacek"),
+    EWA("Ewa"),
+    JAN("Jan"),
+    MAJA("Maja"),
+    VITORIA("Vitoria"),
+    RICARDO("Ricardo"),
+    CRISTIANO("Cristiano"),
+    INES("Ines"),
+    CARMEN("Carmen"),
+    MAXIM("Maxim"),
+    TATYANA("Tatyana"),
+    ASTRID("Astrid"),
+    FILIZ("Filiz"),
+    MIZUKI("Mizuki"),
+    SEOYEON("Seoyeon"),
+    LAILA("Laila"),
+    MAGED("Maged"),
+    TARIK("Tarik"),
+    DAMAYANTI("Damayanti"),
+    MIREN("Miren"),
+    SIN_JI("Sin-Ji"),
+    JORDI("Jordi"),
+    MONTSERRAT("Montserrat"),
+    IVETA("Iveta"),
+    ZUZANA("Zuzana"),
+    TESSA("Tessa"),
+    SATU("Satu"),
+    MELINA("Melina"),
+    NIKOS("Nikos"),
+    CARMIT("Carmit"),
+    LEKHA("Lekha"),
+    MARISKA("Mariska"),
+    SORA("Sora"),
+    TIAN_TIAN("Tian-Tian"),
+    MEI_JIA("Mei-Jia"),
+    NORA("Nora"),
+    HENRIK("Henrik"),
+    LUCIANA("Luciana"),
+    FELIPE("Felipe"),
+    CATARINA("Catarina"),
+    JOANA("Joana"),
+    IOANA("Ioana"),
+    LAURA("Laura"),
+    ALVA("Alva"),
+    OSKAR("Oskar"),
+    KANYA("Kanya"),
+    CEM("Cem"),
+    YELDA("Yelda"),
+    EMPAR("Empar"),
+    UNKNOWN("Unknown");
 
     private static final Map<String, VoiceName> voiceNameIndex = new HashMap<>();
 
@@ -128,11 +127,15 @@ public enum VoiceName {
         }
     }
 
-    @JsonValue
+    private String displayName;
+
+    VoiceName(String displayName) {
+        this.displayName = displayName;
+    }
+
     @Override
     public String toString() {
-        //API requires voice_name to be sent with first character upper cased
-        return StringUtils.capitalize(name().toLowerCase());
+        return displayName;
     }
 
     @JsonCreator
@@ -141,4 +144,8 @@ public enum VoiceName {
         return (foundVoiceName != null) ? foundVoiceName : UNKNOWN;
     }
 
+    @JsonValue
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/src/test/java/com/nexmo/client/voice/VoiceNameTest.java
+++ b/src/test/java/com/nexmo/client/voice/VoiceNameTest.java
@@ -35,4 +35,95 @@ public class VoiceNameTest {
     public void testDeserializeUnknownEnumsFallbackToUnknown() {
         assertEquals(VoiceName.UNKNOWN, VoiceName.fromString("Test Unknown Voice Name"));
     }
+
+    @Test
+    public void testEachVoiceNameForCorrectCapitalization() {
+        // Each voice name should have the first character capitalized.
+        assertEquals(VoiceName.SALLI.getDisplayName(), "Salli");
+        assertEquals(VoiceName.JOEY.getDisplayName(), "Joey");
+        assertEquals(VoiceName.NAJA.getDisplayName(), "Naja");
+        assertEquals(VoiceName.MADS.getDisplayName(), "Mads");
+        assertEquals(VoiceName.MARLENE.getDisplayName(), "Marlene");
+        assertEquals(VoiceName.HANS.getDisplayName(), "Hans");
+        assertEquals(VoiceName.NICOLE.getDisplayName(), "Nicole");
+        assertEquals(VoiceName.RUSSELL.getDisplayName(), "Russell");
+        assertEquals(VoiceName.AMY.getDisplayName(), "Amy");
+        assertEquals(VoiceName.BRIAN.getDisplayName(), "Brian");
+        assertEquals(VoiceName.EMMA.getDisplayName(), "Emma");
+        assertEquals(VoiceName.GWYNETH.getDisplayName(), "Gwyneth");
+        assertEquals(VoiceName.GERAINT.getDisplayName(), "Geraint");
+        assertEquals(VoiceName.RAVEENA.getDisplayName(), "Raveena");
+        assertEquals(VoiceName.CHIPMUNK.getDisplayName(), "Chipmunk");
+        assertEquals(VoiceName.ERIC.getDisplayName(), "Eric");
+        assertEquals(VoiceName.IVY.getDisplayName(), "Ivy");
+        assertEquals(VoiceName.JENNIFER.getDisplayName(), "Jennifer");
+        assertEquals(VoiceName.JUSTIN.getDisplayName(), "Justin");
+        assertEquals(VoiceName.KENDRA.getDisplayName(), "Kendra");
+        assertEquals(VoiceName.KIMBERLY.getDisplayName(), "Kimberly");
+        assertEquals(VoiceName.CONCHITA.getDisplayName(), "Conchita");
+        assertEquals(VoiceName.ENRIQUE.getDisplayName(), "Enrique");
+        assertEquals(VoiceName.PENELOPE.getDisplayName(), "Penelope");
+        assertEquals(VoiceName.MIGUEL.getDisplayName(), "Miguel");
+        assertEquals(VoiceName.CHANTAL.getDisplayName(), "Chantal");
+        assertEquals(VoiceName.CELINE.getDisplayName(), "Celine");
+        assertEquals(VoiceName.MATHIEU.getDisplayName(), "Mathieu");
+        assertEquals(VoiceName.DORA.getDisplayName(), "Dora");
+        assertEquals(VoiceName.KARL.getDisplayName(), "Karl");
+        assertEquals(VoiceName.CARLA.getDisplayName(), "Carla");
+        assertEquals(VoiceName.GIORGIO.getDisplayName(), "Giorgio");
+        assertEquals(VoiceName.LIV.getDisplayName(), "Liv");
+        assertEquals(VoiceName.LOTTE.getDisplayName(), "Lotte");
+        assertEquals(VoiceName.RUBEN.getDisplayName(), "Ruben");
+        assertEquals(VoiceName.AGNIESZKA.getDisplayName(), "Agnieszka");
+        assertEquals(VoiceName.JACEK.getDisplayName(), "Jacek");
+        assertEquals(VoiceName.EWA.getDisplayName(), "Ewa");
+        assertEquals(VoiceName.JAN.getDisplayName(), "Jan");
+        assertEquals(VoiceName.MAJA.getDisplayName(), "Maja");
+        assertEquals(VoiceName.VITORIA.getDisplayName(), "Vitoria");
+        assertEquals(VoiceName.RICARDO.getDisplayName(), "Ricardo");
+        assertEquals(VoiceName.CRISTIANO.getDisplayName(), "Cristiano");
+        assertEquals(VoiceName.INES.getDisplayName(), "Ines");
+        assertEquals(VoiceName.CARMEN.getDisplayName(), "Carmen");
+        assertEquals(VoiceName.MAXIM.getDisplayName(), "Maxim");
+        assertEquals(VoiceName.TATYANA.getDisplayName(), "Tatyana");
+        assertEquals(VoiceName.ASTRID.getDisplayName(), "Astrid");
+        assertEquals(VoiceName.FILIZ.getDisplayName(), "Filiz");
+        assertEquals(VoiceName.MIZUKI.getDisplayName(), "Mizuki");
+        assertEquals(VoiceName.SEOYEON.getDisplayName(), "Seoyeon");
+        assertEquals(VoiceName.LAILA.getDisplayName(), "Laila");
+        assertEquals(VoiceName.MAGED.getDisplayName(), "Maged");
+        assertEquals(VoiceName.TARIK.getDisplayName(), "Tarik");
+        assertEquals(VoiceName.DAMAYANTI.getDisplayName(), "Damayanti");
+        assertEquals(VoiceName.MIREN.getDisplayName(), "Miren");
+        assertEquals(VoiceName.SIN_JI.getDisplayName(), "Sin-Ji");
+        assertEquals(VoiceName.JORDI.getDisplayName(), "Jordi");
+        assertEquals(VoiceName.MONTSERRAT.getDisplayName(), "Montserrat");
+        assertEquals(VoiceName.IVETA.getDisplayName(), "Iveta");
+        assertEquals(VoiceName.ZUZANA.getDisplayName(), "Zuzana");
+        assertEquals(VoiceName.TESSA.getDisplayName(), "Tessa");
+        assertEquals(VoiceName.SATU.getDisplayName(), "Satu");
+        assertEquals(VoiceName.MELINA.getDisplayName(), "Melina");
+        assertEquals(VoiceName.NIKOS.getDisplayName(), "Nikos");
+        assertEquals(VoiceName.CARMIT.getDisplayName(), "Carmit");
+        assertEquals(VoiceName.LEKHA.getDisplayName(), "Lekha");
+        assertEquals(VoiceName.MARISKA.getDisplayName(), "Mariska");
+        assertEquals(VoiceName.SORA.getDisplayName(), "Sora");
+        assertEquals(VoiceName.TIAN_TIAN.getDisplayName(), "Tian-Tian");
+        assertEquals(VoiceName.MEI_JIA.getDisplayName(), "Mei-Jia");
+        assertEquals(VoiceName.NORA.getDisplayName(), "Nora");
+        assertEquals(VoiceName.HENRIK.getDisplayName(), "Henrik");
+        assertEquals(VoiceName.LUCIANA.getDisplayName(), "Luciana");
+        assertEquals(VoiceName.FELIPE.getDisplayName(), "Felipe");
+        assertEquals(VoiceName.CATARINA.getDisplayName(), "Catarina");
+        assertEquals(VoiceName.JOANA.getDisplayName(), "Joana");
+        assertEquals(VoiceName.IOANA.getDisplayName(), "Ioana");
+        assertEquals(VoiceName.LAURA.getDisplayName(), "Laura");
+        assertEquals(VoiceName.ALVA.getDisplayName(), "Alva");
+        assertEquals(VoiceName.OSKAR.getDisplayName(), "Oskar");
+        assertEquals(VoiceName.KANYA.getDisplayName(), "Kanya");
+        assertEquals(VoiceName.CEM.getDisplayName(), "Cem");
+        assertEquals(VoiceName.YELDA.getDisplayName(), "Yelda");
+        assertEquals(VoiceName.EMPAR.getDisplayName(), "Empar");
+        assertEquals(VoiceName.UNKNOWN.getDisplayName(), "Unknown");
+    }
 }


### PR DESCRIPTION
Adds another field to the `VoiceName` enum to explicitly set the display name. This helps to avoid some ambiguity in attempting to programatically set the voice name.

Also adds a method called `getDisplayName` to the enum in order to avoid the reliance on `toString` which should not be used for this purpose.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
