### PR TITLE
Always Apply Version String to Base URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Development]
+
+### Changed
+- Update base uri to always have the version string appended to it.
+
 ## [3.9.0] - 2018-10-18
 ### Added
 - Added missing voices to `VoiceName` enum.

--- a/src/main/java/com/nexmo/client/HttpConfig.java
+++ b/src/main/java/com/nexmo/client/HttpConfig.java
@@ -61,15 +61,15 @@ public class HttpConfig {
     }
 
     public String getVersionedApiBaseUri(String version) {
-        return (isDefaultApiBaseUri()) ? appendVersionToUri(apiBaseUri, version) : apiBaseUri;
+        return appendVersionToUri(apiBaseUri, version);
     }
 
     public String getVersionedRestBaseUri(String version) {
-        return (isDefaultRestBaseUri()) ? appendVersionToUri(restBaseUri, version) : restBaseUri;
+        return appendVersionToUri(restBaseUri, version);
     }
 
     public String getVersionedSnsBaseUri(String version) {
-        return (isDefaultSnsBaseUri()) ? appendVersionToUri(snsBaseUri, version) : snsBaseUri;
+        return appendVersionToUri(snsBaseUri, version);
     }
 
     private String appendVersionToUri(String uri, String version) {

--- a/src/test/java/com/nexmo/client/applications/endpoints/CreateApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/CreateApplicationMethodTest.java
@@ -159,6 +159,6 @@ public class CreateApplicationMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://example.com/applications", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/applications", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/DeleteApplicationMethodTest.java
@@ -81,6 +81,6 @@ public class DeleteApplicationMethodTest {
 
         RequestBuilder builder = method.makeRequest("application-id");
         assertEquals("DELETE", builder.getMethod());
-        assertEquals("https://example.com/applications/application-id", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/applications/application-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/GetApplicationEndpointTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/GetApplicationEndpointTest.java
@@ -115,6 +115,6 @@ public class GetApplicationEndpointTest {
 
         RequestBuilder builder = endpoint.makeRequest("application-id");
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/applications/application-id", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/applications/application-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpointTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/ListApplicationsEndpointTest.java
@@ -156,7 +156,7 @@ public class ListApplicationsEndpointTest {
         RequestBuilder builder = endpoint.makeRequest(request);
         assertEquals("GET", builder.getMethod());
         assertEquals(
-                "https://example.com/applications",
+                "https://example.com/v1/applications",
                 builder.build().getURI().toString()
         );
     }
@@ -185,7 +185,7 @@ public class ListApplicationsEndpointTest {
         RequestBuilder builder = endpoint.makeRequest(request);
         assertEquals("GET", builder.getMethod());
         assertEquals(
-                "https://example.com/applications?page_size=40&page_index=32",
+                "https://example.com/v1/applications?page_size=40&page_index=32",
                 builder.build().getURI().toString()
         );
     }

--- a/src/test/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/endpoints/UpdateApplicationMethodTest.java
@@ -167,6 +167,6 @@ public class UpdateApplicationMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("PUT", builder.getMethod());
-        assertEquals("https://example.com/applications/app-id", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/applications/app-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/redact/RedactMethodTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactMethodTest.java
@@ -102,6 +102,6 @@ public class RedactMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://example.com/redact/transaction", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/redact/transaction", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/CreateCallMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/CreateCallMethodTest.java
@@ -152,6 +152,6 @@ public class CreateCallMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("POST", builder.getMethod());
-        assertEquals("https://example.com/calls", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/calls", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/ListCallsMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ListCallsMethodTest.java
@@ -167,6 +167,6 @@ public class ListCallsMethodTest {
 
         RequestBuilder builder = method.makeRequest(filter);
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/calls?page_size=3", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/calls?page_size=3", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/ReadCallMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/ReadCallMethodTest.java
@@ -101,6 +101,6 @@ public class ReadCallMethodTest {
 
         RequestBuilder builder = method.makeRequest("call-id");
         assertEquals("GET", builder.getMethod());
-        assertEquals("https://example.com/calls/call-id", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/calls/call-id", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/StartStreamMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/StartStreamMethodTest.java
@@ -63,6 +63,6 @@ public class StartStreamMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("PUT", builder.getMethod());
-        assertEquals("https://example.com/calls/uuid/stream", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/calls/uuid/stream", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/StartTalkMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/StartTalkMethodTest.java
@@ -63,6 +63,6 @@ public class StartTalkMethodTest {
 
         RequestBuilder builder = method.makeRequest(request);
         assertEquals("PUT", builder.getMethod());
-        assertEquals("https://example.com/calls/uuid/talk", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/calls/uuid/talk", builder.build().getURI().toString());
     }
 }

--- a/src/test/java/com/nexmo/client/voice/endpoints/StopStreamMethodTest.java
+++ b/src/test/java/com/nexmo/client/voice/endpoints/StopStreamMethodTest.java
@@ -59,6 +59,6 @@ public class StopStreamMethodTest {
 
         RequestBuilder builder = method.makeRequest("uuid");
         assertEquals("DELETE", builder.getMethod());
-        assertEquals("https://example.com/calls/uuid/stream", builder.build().getURI().toString());
+        assertEquals("https://example.com/v1/calls/uuid/stream", builder.build().getURI().toString());
     }
 }


### PR DESCRIPTION
When rewriting base uri we should still append the version string, ie `/v1`.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
