### PR TITLE
Make sure that the entity is sent using UTF-8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Development
+
+## Fixed
+- `AbstractMethod` will force UTF-8 charset for requests using `StringEntity`.
+
 ## [4.1.0] - 2019-03-15
 
 ### Added

--- a/src/main/java/com/nexmo/client/AbstractMethod.java
+++ b/src/main/java/com/nexmo/client/AbstractMethod.java
@@ -32,6 +32,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
@@ -93,6 +94,9 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
                     entityRequest.setEntity(new UrlEncodedFormEntity(requestBuilder.getParameters(),
                             Charset.forName("UTF-8")
                     ));
+                } else if (entity instanceof StringEntity) {
+                    // By default StringEntity is set to ISO-8859-1 but Nexmo expects UTF-8
+                    entityRequest.setEntity(new StringEntity(EntityUtils.toString(entity), Charset.forName("UTF-8")));
                 }
             }
             LOG.debug("Request: " + httpRequest);


### PR DESCRIPTION
Update `AbstractMethod` to make sure that JSON `StringEntity` are sent using UTF-8 as this is what the server expects.

Resolves #227 

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
