### PR TITLE
Fix for message product in redact api

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 4.2.0
+current_version = 4.2.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:build.gradle]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.3.0] - 2019-04-02
+## [4.2.1] - 2019-04-02
 
 ## Fixed
 - Fixed the product name in Redact API for `messages`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.3.0] - 2019-04-02
+
+## Fixed
+- Fixed the product name in Redact API for `messages`.
+
 ## [4.2.0] - 2019-03-20
 
 ## Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,4 @@ documentation, or tests are eligible to be added to this list.
 - GwanYeong Kim ([@gy741](https://github.com/gy741))
 - Guy Khmelnitsky ([@guykh](https://github.com/GuyKh))
 - I Wayan Dharmana ([@wdharmana](https://github.com/wdharmana))
+- Sharif Malik ([@sharif-malik])(https://github.com/sharif-malik))

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For Gradle 3.4 or Higher:
 
 ```groovy
 dependencies {
-    implementation 'com.nexmo:client:4.2.0'
+    implementation 'com.nexmo:client:4.2.1'
 }
 ```
 
@@ -40,7 +40,7 @@ For older versions:
 
 ```groovy
 dependencies {
-    compile 'com.nexmo:client:4.2.0'
+    compile 'com.nexmo:client:4.2.1'
 }
 ```
 
@@ -52,7 +52,7 @@ Add the following to the correct place in your project's POM file:
 <dependency>
       <groupId>com.nexmo</groupId>
       <artifactId>client</artifactId>
-      <version>4.2.0</version>
+      <version>4.2.1</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'eclipse'
 
 group = "com.nexmo"
 archivesBaseName = "client"
-version = "4.2.0"
+version = "4.2.1"
 
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"

--- a/src/main/java/com/nexmo/client/HttpWrapper.java
+++ b/src/main/java/com/nexmo/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.nio.charset.Charset;
  */
 public class HttpWrapper {
     private static final String CLIENT_NAME = "nexmo-java";
-    private static final String CLIENT_VERSION = "4.2.0";
+    private static final String CLIENT_VERSION = "4.2.1";
     private static final String JAVA_VERSION = System.getProperty("java.version");
 
     private AuthCollection authCollection;

--- a/src/main/java/com/nexmo/client/redact/RedactRequest.java
+++ b/src/main/java/com/nexmo/client/redact/RedactRequest.java
@@ -87,7 +87,7 @@ public class RedactRequest {
         NUMBER_INSIGHTS("number-insight"),
         VERIFY("verify"),
         VERIFY_SDK("verify-sdk"),
-        MESSAGE("message"),
+        MESSAGES("messages"),
         WORKFLOW("workflow");
 
         private String value;

--- a/src/test/java/com/nexmo/client/redact/RedactRequestTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactRequestTest.java
@@ -76,8 +76,8 @@ public class RedactRequestTest {
     }
 
     @Test
-    public void testProductMessage() {
-        String json = "{\"id\":\"testId\",\"product\":\"message\"}";
+    public void testProductMessages() {
+        String json = "{\"id\":\"testId\",\"product\":\"messages\"}";
         assertEquals(new RedactRequest("testId", RedactRequest.Product.MESSAGES).toJson(), json);
     }
 

--- a/src/test/java/com/nexmo/client/redact/RedactRequestTest.java
+++ b/src/test/java/com/nexmo/client/redact/RedactRequestTest.java
@@ -78,7 +78,7 @@ public class RedactRequestTest {
     @Test
     public void testProductMessage() {
         String json = "{\"id\":\"testId\",\"product\":\"message\"}";
-        assertEquals(new RedactRequest("testId", RedactRequest.Product.MESSAGE).toJson(), json);
+        assertEquals(new RedactRequest("testId", RedactRequest.Product.MESSAGES).toJson(), json);
     }
 
     @Test


### PR DESCRIPTION
This change to fix the issue #237 which describes that product name in the RedactRequest Enum is wrong and doesn't work for me. 

When I did this changes, it works like charm. 

Customer support from Nexmo already confirmed that it should be **messages** instead of **message** as product name. 

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
