### PR TITLE
Fix Update Application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 - Added header (application/json) for Redact client.
+- Fixed Application Update to send json body as it is what the API now expects.
 
 ## [4.2.1] - 2019-04-02
 

--- a/src/main/java/com/nexmo/client/applications/ApplicationType.java
+++ b/src/main/java/com/nexmo/client/applications/ApplicationType.java
@@ -21,10 +21,12 @@
  */
 package com.nexmo.client.applications;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum ApplicationType {
     VOICE;
 
-
+    @JsonValue
     @Override
     public String toString() {
         return this.name().toLowerCase();

--- a/src/main/java/com/nexmo/client/applications/UpdateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/applications/UpdateApplicationMethod.java
@@ -27,6 +27,7 @@ import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
@@ -49,14 +50,19 @@ class UpdateApplicationMethod extends AbstractMethod<UpdateApplicationRequest, A
 
     @Override
     public RequestBuilder makeRequest(UpdateApplicationRequest request) throws NexmoClientException, UnsupportedEncodingException {
-        RequestBuilder requestBuilder = RequestBuilder.put(
-                httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + request.getApplicationId());
-        request.addParams(requestBuilder);
-        return requestBuilder;
+        return RequestBuilder.put(
+                httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + request.getApplicationId())
+                .setHeader("Content-Type", "application/json")
+                .setEntity(new StringEntity(request.toJson()));
     }
 
     @Override
     public ApplicationDetails parseResponse(HttpResponse response) throws IOException {
         return ApplicationDetails.fromJson(new BasicResponseHandler().handleResponse(response));
+    }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws NexmoClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsJsonProperties(request);
     }
 }

--- a/src/main/java/com/nexmo/client/applications/UpdateApplicationRequest.java
+++ b/src/main/java/com/nexmo/client/applications/UpdateApplicationRequest.java
@@ -21,8 +21,15 @@
  */
 package com.nexmo.client.applications;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexmo.client.NexmoUnexpectedException;
 import org.apache.http.client.methods.RequestBuilder;
 
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class UpdateApplicationRequest {
     private final String applicationId;
     private final String name;
@@ -50,6 +57,7 @@ public class UpdateApplicationRequest {
         this.eventMethod = eventMethod;
     }
 
+    @JsonIgnore
     public String getApplicationId() {
         return applicationId;
     }
@@ -62,14 +70,17 @@ public class UpdateApplicationRequest {
         return type;
     }
 
+    @JsonProperty("answer_url")
     public String getAnswerUrl() {
         return answerUrl;
     }
 
+    @JsonProperty("event_url")
     public String getEventUrl() {
         return eventUrl;
     }
 
+    @JsonProperty("answer_method")
     public String getAnswerMethod() {
         return answerMethod;
     }
@@ -78,12 +89,22 @@ public class UpdateApplicationRequest {
         this.answerMethod = answerMethod;
     }
 
+    @JsonProperty("event_method")
     public String getEventMethod() {
         return eventMethod;
     }
 
     public void setEventMethod(String eventMethod) {
         this.eventMethod = eventMethod;
+    }
+
+    public String toJson() {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException jpe) {
+            throw new NexmoUnexpectedException("Failed to produce json from UpdateApplicationRequest object.", jpe);
+        }
     }
 
     public void addParams(RequestBuilder request) {

--- a/src/main/java/com/nexmo/client/auth/AbstractAuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/AbstractAuthMethod.java
@@ -36,4 +36,10 @@ public abstract class AbstractAuthMethod implements AuthMethod {
         throw new UnsupportedOperationException(
                 "applyAsBasicAuth not implemented for " + this.getClass().getCanonicalName());
     }
+
+    @Override
+    public RequestBuilder applyAsJsonProperties(RequestBuilder request) {
+        throw new UnsupportedOperationException(
+                "applyAsJsonProperties not implemented for " + this.getClass().getCanonicalName());
+    }
 }

--- a/src/test/java/com/nexmo/client/applications/UpdateApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/applications/UpdateApplicationMethodTest.java
@@ -27,10 +27,9 @@ import com.nexmo.client.TestUtils;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -62,14 +61,7 @@ public class UpdateApplicationMethodTest {
         RequestBuilder builder = this.endpoint.makeRequest(update);
         assertEquals("PUT", builder.getMethod());
         assertEquals("https://api.nexmo.com/v1/applications/app-id", builder.build().getURI().toString());
-
-        Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
-        assertEquals("app name", params.get("name"));
-        assertEquals("https://example.com/event", params.get("event_url"));
-        assertEquals("https://example.com/answer", params.get("answer_url"));
-        assertEquals("PUT", params.get("answer_method"));
-        assertEquals("DELETE", params.get("event_method"));
-        assertNull(params.get("app_id"));
+        assertEquals("{\"name\":\"app name\",\"type\":\"voice\",\"answer_url\":\"https://example.com/answer\",\"event_url\":\"https://example.com/event\",\"answer_method\":\"PUT\",\"event_method\":\"DELETE\"}", EntityUtils.toString(builder.getEntity()));
     }
 
     @Test
@@ -83,15 +75,10 @@ public class UpdateApplicationMethodTest {
 
         RequestBuilder builder = this.endpoint.makeRequest(update);
         assertEquals("PUT", builder.getMethod());
-        assertEquals("https://api.nexmo.com/v1/applications/app-id", builder.build().getURI().toString());
 
-        Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
-        assertEquals("app name", params.get("name"));
-        assertEquals("https://example.com/event", params.get("event_url"));
-        assertEquals("https://example.com/answer", params.get("answer_url"));
-        assertNull(params.get("answer_method"));
-        assertNull(params.get("event_method"));
-        assertNull(params.get("app_id"));
+        assertEquals("application/json", builder.getFirstHeader("Content-Type").getValue());
+        assertEquals("https://api.nexmo.com/v1/applications/app-id", builder.build().getURI().toString());
+        assertEquals("{\"name\":\"app name\",\"type\":\"voice\",\"answer_url\":\"https://example.com/answer\",\"event_url\":\"https://example.com/event\"}", EntityUtils.toString(builder.getEntity()));
     }
 
     @Test

--- a/src/test/java/com/nexmo/client/auth/TokenAuthMethodTest.java
+++ b/src/test/java/com/nexmo/client/auth/TokenAuthMethodTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2017 Nexmo Inc
+ * Copyright (c) 2011-2019 Nexmo Inc
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,28 +22,22 @@
 package com.nexmo.client.auth;
 
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 
-public interface AuthMethod extends Comparable<AuthMethod> {
-    RequestBuilder apply(RequestBuilder request);
+public class TokenAuthMethodTest {
+    @Test
+    public void testAddingApiKeyAndSecretToJson() throws Exception {
+        AuthMethod auth = new TokenAuthMethod("apikey", "secret");
+        String before = "{\"name\":\"app name\",\"type\":\"voice\",\"answer_url\":\"https://example.com/answer\",\"event_url\":\"https://example.com/event\"}";
+        RequestBuilder requestBuilder = RequestBuilder.get().setEntity(new StringEntity(before));
 
-    /**
-     * Apply the authentication to the header as basic authentication.
-     *
-     * @param requestBuilder The request being built
-     *
-     * @return RequestBuilder for more building of the request.
-     */
-    RequestBuilder applyAsBasicAuth(RequestBuilder requestBuilder);
+        RequestBuilder requestBuilderWithAuthentication = auth.applyAsJsonProperties(requestBuilder);
 
-    /**
-     * Apply the authentication by adding it to the entity payload.
-     *
-     * @param requestBuilder The request being built
-     *
-     * @return RequestBuilder for more building of the request.
-     */
-    RequestBuilder applyAsJsonProperties(RequestBuilder requestBuilder);
-
-    int getSortKey();
+        String after = "{\"name\":\"app name\",\"type\":\"voice\",\"answer_url\":\"https://example.com/answer\",\"event_url\":\"https://example.com/event\",\"api_key\":\"apikey\",\"api_secret\":\"secret\"}";
+        assertEquals(after, EntityUtils.toString(requestBuilderWithAuthentication.getEntity()));
+    }
 }


### PR DESCRIPTION
Update application (v1) was not functioning correctly because the endpoint was expecting a json body. It also expected api key and secret parameters to be added to the json body.

I updated the `UpdateApplicationMethod` to switch to using a json payload as a fix before application v2 can be implemented. I also added the ability for `TokenAuthMethod` to attach api credentials to a json entity.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
