### PR TITLE
Fix UTF-8 Encoding

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 4.2.1
+current_version = 4.3.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}
 
 [bumpversion:file:build.gradle]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Development]
+
+## Fixed
+- Fix UTF-8 Encoding for endpoints using JSON bodies.
+
 ## [4.3.0] - 2019-04-25 
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Development] 
+## [4.3.0] - 2019-04-25 
 
 ## Added
 - Added `NotifyAction` for use in `NCCO`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For Gradle 3.4 or Higher:
 
 ```groovy
 dependencies {
-    implementation 'com.nexmo:client:4.2.1'
+    implementation 'com.nexmo:client:4.3.0'
 }
 ```
 
@@ -40,7 +40,7 @@ For older versions:
 
 ```groovy
 dependencies {
-    compile 'com.nexmo:client:4.2.1'
+    compile 'com.nexmo:client:4.3.0'
 }
 ```
 
@@ -52,7 +52,7 @@ Add the following to the correct place in your project's POM file:
 <dependency>
       <groupId>com.nexmo</groupId>
       <artifactId>client</artifactId>
-      <version>4.2.1</version>
+      <version>4.3.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'eclipse'
 
 group = "com.nexmo"
 archivesBaseName = "client"
-version = "4.2.1"
+version = "4.3.0"
 
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"

--- a/src/main/java/com/nexmo/client/AbstractMethod.java
+++ b/src/main/java/com/nexmo/client/AbstractMethod.java
@@ -32,7 +32,6 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
@@ -46,14 +45,14 @@ import java.util.Set;
  * Abstract class to assist in implementing a call against a REST endpoint.
  * <p>
  * Concrete implementations must implement {@link #makeRequest(Object)} to construct a {@link RequestBuilder} from the
- * provided parameterized request object, and {@link #parseResponse(HttpResponse)} to construct the parameterized
- * {@link HttpResponse} object.
+ * provided parameterized request object, and {@link #parseResponse(HttpResponse)} to construct the parameterized {@link
+ * HttpResponse} object.
  * <p>
  * The REST call is executed by calling {@link #execute(Object)}.
  *
  * @param <RequestT> The type of the method-specific request object that will be used to construct an HTTP request
- * @param <ResultT>  The type of method-specific response object which will be constructed from the returned
- *                   HTTP response
+ * @param <ResultT>  The type of method-specific response object which will be constructed from the returned HTTP
+ *                   response
  */
 public abstract class AbstractMethod<RequestT, ResultT> implements Method<RequestT, ResultT> {
     private static final Log LOG = LogFactory.getLog(AbstractMethod.class);
@@ -94,9 +93,6 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
                     entityRequest.setEntity(new UrlEncodedFormEntity(requestBuilder.getParameters(),
                             Charset.forName("UTF-8")
                     ));
-                } else if (entity instanceof StringEntity) {
-                    // By default StringEntity is set to ISO-8859-1 but Nexmo expects UTF-8
-                    entityRequest.setEntity(new StringEntity(EntityUtils.toString(entity), Charset.forName("UTF-8")));
                 }
             }
             LOG.debug("Request: " + httpRequest);
@@ -118,7 +114,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
      * @param request A RequestBuilder which has not yet had authentication information applied
      *
      * @return A RequestBuilder with appropriate authentication information applied (may or not be the same instance as
-     *         <pre>request</pre>)
+     * <pre>request</pre>)
      *
      * @throws NexmoClientException If no appropriate {@link AuthMethod} is available
      */

--- a/src/main/java/com/nexmo/client/HttpWrapper.java
+++ b/src/main/java/com/nexmo/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.nio.charset.Charset;
  */
 public class HttpWrapper {
     private static final String CLIENT_NAME = "nexmo-java";
-    private static final String CLIENT_VERSION = "4.2.1";
+    private static final String CLIENT_VERSION = "4.3.0";
     private static final String JAVA_VERSION = System.getProperty("java.version");
 
     private AuthCollection authCollection;

--- a/src/main/java/com/nexmo/client/applications/UpdateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/applications/UpdateApplicationMethod.java
@@ -27,6 +27,7 @@ import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 
@@ -53,7 +54,7 @@ class UpdateApplicationMethod extends AbstractMethod<UpdateApplicationRequest, A
         return RequestBuilder.put(
                 httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + request.getApplicationId())
                 .setHeader("Content-Type", "application/json")
-                .setEntity(new StringEntity(request.toJson()));
+                .setEntity(new StringEntity(request.toJson(), ContentType.APPLICATION_JSON));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
+++ b/src/main/java/com/nexmo/client/auth/TokenAuthMethod.java
@@ -28,6 +28,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
@@ -65,7 +66,7 @@ public class TokenAuthMethod extends AbstractAuthMethod {
             json.put("api_key", this.apiKey);
             json.put("api_secret", this.apiSecret);
 
-            return request.setEntity(new StringEntity(json.toString()));
+            return request.setEntity(new StringEntity(json.toString(), ContentType.APPLICATION_JSON));
         } catch (IOException e) {
             throw new NexmoUnexpectedException("Failed to attach api key and secret to json.", e);
         }

--- a/src/main/java/com/nexmo/client/voice/CreateCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/CreateCallMethod.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 
@@ -50,7 +51,7 @@ class CreateCallMethod extends AbstractMethod<Call, CallEvent> {
     public RequestBuilder makeRequest(Call request) throws NexmoClientException, UnsupportedEncodingException {
         return RequestBuilder.post(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH)
                 .setHeader("Content-Type", "application/json")
-                .setEntity(new StringEntity(request.toJson()));
+                .setEntity(new StringEntity(request.toJson(), ContentType.APPLICATION_JSON));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/ModifyCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/ModifyCallMethod.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 
@@ -57,7 +58,7 @@ class ModifyCallMethod extends AbstractMethod<CallModifier, ModifyCallResponse> 
         return RequestBuilder
                 .put(uri)
                 .setHeader("Content-Type", "application/json")
-                .setEntity(new StringEntity(request.toJson()));
+                .setEntity(new StringEntity(request.toJson(), ContentType.APPLICATION_JSON));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/SendDtmfMethod.java
+++ b/src/main/java/com/nexmo/client/voice/SendDtmfMethod.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 
@@ -56,7 +57,7 @@ class SendDtmfMethod extends AbstractMethod<DtmfRequest, DtmfResponse> {
         String uri = this.uri + request.getUuid() + "/dtmf";
         return RequestBuilder.put(uri)
                 .setHeader("Content-Type", "application/json")
-                .setEntity(new StringEntity(request.toJson()));
+                .setEntity(new StringEntity(request.toJson(), ContentType.APPLICATION_JSON));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/StartStreamMethod.java
+++ b/src/main/java/com/nexmo/client/voice/StartStreamMethod.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 
@@ -56,7 +57,7 @@ class StartStreamMethod extends AbstractMethod<StreamRequest, StreamResponse> {
         return RequestBuilder
                 .put(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + request.getUuid() + "/stream")
                 .setHeader("Content-Type", "application/json")
-                .setEntity(new StringEntity(request.toJson()));
+                .setEntity(new StringEntity(request.toJson(), ContentType.APPLICATION_JSON));
     }
 
     @Override

--- a/src/main/java/com/nexmo/client/voice/StartTalkMethod.java
+++ b/src/main/java/com/nexmo/client/voice/StartTalkMethod.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 
@@ -56,7 +57,7 @@ class StartTalkMethod extends AbstractMethod<TalkRequest, TalkResponse> {
         return RequestBuilder
                 .put(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + request.getUuid() + "/talk")
                 .setHeader("Content-Type", "application/json")
-                .setEntity(new StringEntity(request.toJson()));
+                .setEntity(new StringEntity(request.toJson(), ContentType.APPLICATION_JSON));
     }
 
     @Override

--- a/src/test/java/com/nexmo/client/auth/TokenAuthMethodTest.java
+++ b/src/test/java/com/nexmo/client/auth/TokenAuthMethodTest.java
@@ -22,6 +22,7 @@
 package com.nexmo.client.auth;
 
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.junit.Test;
@@ -33,7 +34,7 @@ public class TokenAuthMethodTest {
     public void testAddingApiKeyAndSecretToJson() throws Exception {
         AuthMethod auth = new TokenAuthMethod("apikey", "secret");
         String before = "{\"name\":\"app name\",\"type\":\"voice\",\"answer_url\":\"https://example.com/answer\",\"event_url\":\"https://example.com/event\"}";
-        RequestBuilder requestBuilder = RequestBuilder.get().setEntity(new StringEntity(before));
+        RequestBuilder requestBuilder = RequestBuilder.get().setEntity(new StringEntity(before, ContentType.APPLICATION_JSON));
 
         RequestBuilder requestBuilderWithAuthentication = auth.applyAsJsonProperties(requestBuilder);
 


### PR DESCRIPTION
Previously there was a fix in the `AbstractMethod` that would de-encode and re-encode a `StringEntity` into `UTF-8`. However, this doesn't work as it was intended.

This fix changes all of the `StringEntity` instantiations to supply a `ContentType.APPLICATION_JSON` which will force the default Charset to use `UTF-8`

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
