### PR TITLE
Migrate from Auth0 JWT to Nexmo JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Development]
 
-## Changed
+### Changed
+- Changed from Auth0 to the [Nexmo JWT Library](https://github.com/nexmo/nexmo-jwt-jdk).
 - Renamed the `com.nexmo.client.applications` package to `com.nexmo.client.application`
 - `ApplicationClient` now supports the [Applications v2](https://developer.nexmo.com/api/application.v2) API. This change has resulted in some backwards incompatibility.
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,6 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 repositories {
-    maven {
-        url 'https://oss.sonatype.org/content/repositories/snapshots/'
-    }
     mavenCentral()
 }
 
@@ -44,7 +41,7 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
     compile 'io.openapitools.jackson.dataformat:jackson-dataformat-hal:1.0.4'
     compile 'javax.xml.bind:jaxb-api:2.3.0'
-    compile "com.nexmo:jwt:1.0.0-SNAPSHOT"
+    compile "com.nexmo:jwt:1.0.0"
 
     testCompile "javax.servlet:javax.servlet-api:3.1.0"
     testCompile 'junit:junit:4.4'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.gradle.internal.jvm.Jvm
-
 buildscript {
     repositories {
         jcenter()
@@ -26,6 +24,9 @@ sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
 repositories {
+    maven {
+        url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
     mavenCentral()
 }
 
@@ -41,9 +42,9 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.5'
     compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
-    compile 'com.auth0:java-jwt:2.2.1'
     compile 'io.openapitools.jackson.dataformat:jackson-dataformat-hal:1.0.4'
     compile 'javax.xml.bind:jaxb-api:2.3.0'
+    compile "com.nexmo:jwt:1.0.0-SNAPSHOT"
 
     testCompile "javax.servlet:javax.servlet-api:3.1.0"
     testCompile 'junit:junit:4.4'

--- a/src/main/java/com/nexmo/client/NexmoClient.java
+++ b/src/main/java/com/nexmo/client/NexmoClient.java
@@ -39,9 +39,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
 
 /**
  * Top-level Nexmo API client object.
@@ -130,7 +127,7 @@ public class NexmoClient {
      */
     public String generateJwt() throws NexmoUnacceptableAuthException {
         JWTAuthMethod authMethod = this.httpWrapper.getAuthCollection().getAuth(JWTAuthMethod.class);
-        return authMethod.constructToken(System.currentTimeMillis() / 1000L, JWTAuthMethod.constructJTI());
+        return authMethod.generateToken();
     }
 
     /**
@@ -187,7 +184,8 @@ public class NexmoClient {
         }
 
         /**
-         * When setting an apiKey, it is also expected that {@link #apiSecret(String)} and/or {@link #signatureSecret(String)} will also be set.
+         * When setting an apiKey, it is also expected that {@link #apiSecret(String)} and/or {@link
+         * #signatureSecret(String)} will also be set.
          *
          * @param apiKey The API Key found in the dashboard for your account.
          *
@@ -223,7 +221,8 @@ public class NexmoClient {
         }
 
         /**
-         * When setting the contents of your private key, it is also expected that {@link #applicationId(String)} will also be set.
+         * When setting the contents of your private key, it is also expected that {@link #applicationId(String)} will
+         * also be set.
          *
          * @param privateKeyContents The contents of your private key used for JWT generation.
          *
@@ -235,7 +234,8 @@ public class NexmoClient {
         }
 
         /**
-         * When setting the contents of your private key, it is also expected that {@link #applicationId(String)} will also be set.
+         * When setting the contents of your private key, it is also expected that {@link #applicationId(String)} will
+         * also be set.
          *
          * @param privateKeyContents The contents of your private key used for JWT generation.
          *
@@ -246,7 +246,8 @@ public class NexmoClient {
         }
 
         /**
-         * When setting the path of your private key, it is also expected that {@link #applicationId(String)} will also be set.
+         * When setting the path of your private key, it is also expected that {@link #applicationId(String)} will also
+         * be set.
          *
          * @param privateKeyPath The path to your private key used for JWT generation.
          *
@@ -257,7 +258,8 @@ public class NexmoClient {
         }
 
         /**
-         * When setting the path of your private key, it is also expected that {@link #applicationId(String)} will also be set.
+         * When setting the path of your private key, it is also expected that {@link #applicationId(String)} will also
+         * be set.
          *
          * @param privateKeyPath The path to your private key used for JWT generation.
          *
@@ -301,11 +303,7 @@ public class NexmoClient {
             }
 
             if (applicationId != null && privateKeyContents != null) {
-                try {
-                    authMethods.add(new JWTAuthMethod(applicationId, privateKeyContents));
-                } catch (NoSuchAlgorithmException | InvalidKeyException | InvalidKeySpecException e) {
-                    throw new NexmoClientCreationException("Failed to generate JWT Authentication method.", e);
-                }
+                authMethods.add(new JWTAuthMethod(applicationId, privateKeyContents));
             }
 
             return authMethods;

--- a/src/test/java/com/nexmo/client/NexmoClientTest.java
+++ b/src/test/java/com/nexmo/client/NexmoClientTest.java
@@ -21,12 +21,12 @@
  */
 package com.nexmo.client;
 
-import com.auth0.jwt.JWTVerifier;
-import com.auth0.jwt.internal.org.bouncycastle.util.Strings;
 import com.nexmo.client.auth.*;
 import com.nexmo.client.voice.Call;
 import com.nexmo.client.voice.CallEvent;
 import com.nexmo.client.voice.CallStatus;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
@@ -38,13 +38,13 @@ import org.apache.http.message.BasicNameValuePair;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +63,7 @@ public class NexmoClientTest {
         HttpEntity entity = mock(HttpEntity.class);
 
         when(result.execute(any(HttpUriRequest.class))).thenReturn(response);
-        when(entity.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes("UTF-8")));
+        when(entity.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
         when(sl.getStatusCode()).thenReturn(statusCode);
         when(response.getStatusLine()).thenReturn(sl);
         when(response.getEntity()).thenReturn(entity);
@@ -105,8 +105,7 @@ public class NexmoClientTest {
         KeyFactory kf = KeyFactory.getInstance("RSA");
         PublicKey key = kf.generatePublic(spec);
 
-        final JWTVerifier verifier = new JWTVerifier(key);
-        final Map<String, Object> claims = verifier.verify(constructedToken);
+        Claims claims = Jwts.parser().setSigningKey(key).parseClaimsJws(constructedToken).getBody();
 
         assertEquals("application-id", claims.get("application_id"));
     }
@@ -195,7 +194,7 @@ public class NexmoClientTest {
     @Test
     public void testApplicationIdWithCertContentsAsString() throws Exception {
         TestUtils testUtils = new TestUtils();
-        String key = Strings.fromByteArray(testUtils.loadKey("test/keys/application_key"));
+        String key = new String(testUtils.loadKey("test/keys/application_key"));
 
         NexmoClient nexmoClient = NexmoClient.builder().applicationId("app-id").privateKeyContents(key).build();
         AuthCollection authCollection = nexmoClient.getHttpWrapper().getAuthCollection();
@@ -235,12 +234,6 @@ public class NexmoClientTest {
 
         assertEquals(1, requestBuilder.getHeaders("Authorization").length);
         assertEquals("Bearer ", requestBuilder.getFirstHeader("Authorization").getValue().substring(0, 7));
-    }
-
-    @Test(expected = NexmoClientCreationException.class)
-    public void testApplicationIdWithInvalidCert() throws Exception {
-        NexmoClient.builder().applicationId("app-id").privateKeyContents("invalid").build();
-
     }
 
     @Test

--- a/src/test/java/com/nexmo/client/auth/JWTAuthMethodTest.java
+++ b/src/test/java/com/nexmo/client/auth/JWTAuthMethodTest.java
@@ -22,19 +22,14 @@
 package com.nexmo.client.auth;
 
 
-import com.auth0.jwt.JWTVerifier;
 import com.nexmo.client.TestUtils;
 import org.apache.http.client.methods.RequestBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.security.*;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.X509EncodedKeySpec;
-import java.util.Map;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class JWTAuthMethodTest {
     private TestUtils testUtils;
@@ -48,46 +43,9 @@ public class JWTAuthMethodTest {
         auth = new JWTAuthMethod("application-id", keyBytes);
     }
 
-    @Test public void testSavedKey() throws Exception {
-        byte[] keyBytes = testUtils.loadKey("test/keys/application_key2");
-        auth = new JWTAuthMethod("application-id", keyBytes);
-    }
-
     @Test
-    public void testConstructToken() throws Exception {
-        String constructedToken = auth.constructToken(1234, "1111111");
-
-        byte[] keyBytes = testUtils.loadKey("test/keys/application_public_key.der");
-        X509EncodedKeySpec spec = new X509EncodedKeySpec(keyBytes);
-        KeyFactory kf = KeyFactory.getInstance("RSA");
-        PublicKey key = kf.generatePublic(spec);
-
-        final JWTVerifier verifier = new JWTVerifier(key);
-        final Map<String, Object> claims = verifier.verify(constructedToken);
-
-        assertEquals(1234, claims.get("iat"));
-        assertEquals("1111111", claims.get("jti"));
-        assertEquals("application-id", claims.get("application_id"));
-    }
-
-    @Test
-    public void testDecodePrivateKeyInvalid() throws Exception {
-        try {
-            auth = new JWTAuthMethod("application-id", new byte[]{0x00});
-            fail("Invalid bytes should result in InvalidKeySpecException");
-        } catch (InvalidKeySpecException e) {
-            // this is expected
-        }
-    }
-
-    @Test
-    public void testDecodePrivateKeyCannotDecode() throws Exception {
-        try {
-            auth = new JWTAuthMethod("application-id", new byte[]{'-'});
-            fail("Invalid key should result in InvalidKeySpecException");
-        } catch (InvalidKeyException e) {
-            // this is expected
-        }
+    public void testSavedKeyUsingPath() throws Exception {
+        auth = new JWTAuthMethod("application-id", Paths.get("src/test/resources/com/nexmo/client/test/keys/application_key2"));
     }
 
     @Test


### PR DESCRIPTION
Instead of relying on Auth0, this PR changes the Server SDK to use the [Nexmo JWT Library](https://github.com/nexmo/nexmo-jwt-jdk).

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
