### PR TITLE
Convert Checked Exceptions to Unchecked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed from Auth0 to the [Nexmo JWT Library](https://github.com/nexmo/nexmo-jwt-jdk).
 - Renamed the `com.nexmo.client.applications` package to `com.nexmo.client.application`
 - `ApplicationClient` now supports the [Applications v2](https://developer.nexmo.com/api/application.v2) API. This change has resulted in some backwards incompatibility.
+- `NexmoClientException` is now a `RuntimeException`. The various sub client methods will still declare that it is being thrown, but it is no longer a requirement to catch the exception. Additionally, the `IOException` that was being thrown in each method has been converted to a `NexmoResponseParseException` to more accurately reflect when it is thrown. This is also an unchecked exception and catching is no longer required.
 
 ## [4.4.0] - 2019-06-10
 

--- a/src/main/java/com/nexmo/client/AbstractMethod.java
+++ b/src/main/java/com/nexmo/client/AbstractMethod.java
@@ -71,10 +71,9 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
      *
      * @return A ResultT representing the response from the executed REST call
      *
-     * @throws IOException          if an exception occurs making the REST call
      * @throws NexmoClientException if there is a problem parsing the HTTP response
      */
-    public ResultT execute(RequestT request) throws IOException, NexmoClientException {
+    public ResultT execute(RequestT request) throws NexmoResponseParseException, NexmoClientException {
         try {
             RequestBuilder requestBuilder = applyAuth(makeRequest(request));
             HttpUriRequest httpRequest = requestBuilder.build();
@@ -104,6 +103,8 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
             return parseResponse(response);
         } catch (UnsupportedEncodingException uee) {
             throw new NexmoUnexpectedException("UTF-8 encoding is not supported by this JVM.", uee);
+        } catch (IOException io) {
+            throw new NexmoResponseParseException("Unable to parse response.", io);
         }
     }
 
@@ -154,10 +155,9 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
      *
      * @return A ResultT representing the response from the executed REST call
      *
-     * @throws NexmoClientException         if a problem is encountered constructing the request or response.
      * @throws UnsupportedEncodingException if UTF-8 encoding is not supported by the JVM
      */
-    public abstract RequestBuilder makeRequest(RequestT request) throws NexmoClientException, UnsupportedEncodingException;
+    public abstract RequestBuilder makeRequest(RequestT request) throws UnsupportedEncodingException;
 
     /**
      * Construct a ResultT representing the contents of the HTTP response returned from the Nexmo Voice API.
@@ -168,5 +168,5 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
      *
      * @throws IOException if a problem occurs parsing the response
      */
-    public abstract ResultT parseResponse(HttpResponse response) throws IOException, NexmoClientException;
+    public abstract ResultT parseResponse(HttpResponse response) throws IOException;
 }

--- a/src/main/java/com/nexmo/client/NexmoClient.java
+++ b/src/main/java/com/nexmo/client/NexmoClient.java
@@ -252,9 +252,15 @@ public class NexmoClient {
          * @param privateKeyPath The path to your private key used for JWT generation.
          *
          * @return The {@link Builder} to keep building.
+         *
+         * @throws NexmoUnableToReadPrivateKeyException if the private key could not be read from the file system.
          */
-        public Builder privateKeyPath(Path privateKeyPath) throws IOException {
-            return privateKeyContents(Files.readAllBytes(privateKeyPath));
+        public Builder privateKeyPath(Path privateKeyPath) throws NexmoUnableToReadPrivateKeyException {
+            try {
+                return privateKeyContents(Files.readAllBytes(privateKeyPath));
+            } catch (IOException e) {
+                throw new NexmoUnableToReadPrivateKeyException("Unable to read private key at " + privateKeyPath, e);
+            }
         }
 
         /**
@@ -264,8 +270,10 @@ public class NexmoClient {
          * @param privateKeyPath The path to your private key used for JWT generation.
          *
          * @return The {@link Builder} to keep building.
+         *
+         * @throws NexmoUnableToReadPrivateKeyException if the private key could not be read from the file system.
          */
-        public Builder privateKeyPath(String privateKeyPath) throws IOException {
+        public Builder privateKeyPath(String privateKeyPath) throws NexmoUnableToReadPrivateKeyException {
             return privateKeyPath(Paths.get(privateKeyPath));
         }
 

--- a/src/main/java/com/nexmo/client/NexmoClientException.java
+++ b/src/main/java/com/nexmo/client/NexmoClientException.java
@@ -21,7 +21,7 @@
  */
 package com.nexmo.client;
 
-public class NexmoClientException extends Exception {
+public class NexmoClientException extends RuntimeException {
     public NexmoClientException() {
         super();
     }

--- a/src/main/java/com/nexmo/client/NexmoUnableToReadPrivateKeyException.java
+++ b/src/main/java/com/nexmo/client/NexmoUnableToReadPrivateKeyException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2011-2019 Nexmo Inc
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nexmo.client;
+
+public class NexmoUnableToReadPrivateKeyException extends RuntimeException {
+    public NexmoUnableToReadPrivateKeyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/nexmo/client/account/AccountClient.java
+++ b/src/main/java/com/nexmo/client/account/AccountClient.java
@@ -21,12 +21,7 @@
  */
 package com.nexmo.client.account;
 
-import com.nexmo.client.AbstractClient;
-import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClient;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
+import com.nexmo.client.*;
 
 /**
  * A client for talking to the Nexmo Account API. The standard way to obtain an instance of this class is to use {@link
@@ -56,7 +51,7 @@ public class AccountClient extends AbstractClient {
         this.settings = new SettingsEndpoint(httpWrapper);
     }
 
-    public BalanceResponse getBalance() throws IOException, NexmoClientException {
+    public BalanceResponse getBalance() throws NexmoResponseParseException, NexmoClientException {
         return this.balance.execute();
     }
 
@@ -67,14 +62,14 @@ public class AccountClient extends AbstractClient {
      *
      * @return PricingResponse object which contains the results from the API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public PricingResponse getVoicePrice(String country) throws IOException, NexmoClientException {
+    public PricingResponse getVoicePrice(String country) throws NexmoResponseParseException, NexmoClientException {
         return getVoicePrice(new PricingRequest(country));
     }
 
-    private PricingResponse getVoicePrice(PricingRequest pricingRequest) throws IOException, NexmoClientException {
+    private PricingResponse getVoicePrice(PricingRequest pricingRequest) throws NexmoResponseParseException, NexmoClientException {
         return this.pricing.getPrice(ServiceType.VOICE, pricingRequest);
     }
 
@@ -85,14 +80,14 @@ public class AccountClient extends AbstractClient {
      *
      * @return PricingResponse object which contains the results from the API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public PricingResponse getSmsPrice(String country) throws IOException, NexmoClientException {
+    public PricingResponse getSmsPrice(String country) throws NexmoResponseParseException, NexmoClientException {
         return getSmsPrice(new PricingRequest(country));
     }
 
-    private PricingResponse getSmsPrice(PricingRequest pricingRequest) throws IOException, NexmoClientException {
+    private PricingResponse getSmsPrice(PricingRequest pricingRequest) throws NexmoResponseParseException, NexmoClientException {
         return this.pricing.getPrice(ServiceType.SMS, pricingRequest);
     }
 
@@ -104,14 +99,14 @@ public class AccountClient extends AbstractClient {
      *
      * @return PrefixPricingResponse object which contains the results from the API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public PrefixPricingResponse getPrefixPrice(ServiceType type, String prefix) throws IOException, NexmoClientException {
+    public PrefixPricingResponse getPrefixPrice(ServiceType type, String prefix) throws NexmoResponseParseException, NexmoClientException {
         return getPrefixPrice(new PrefixPricingRequest(type, prefix));
     }
 
-    private PrefixPricingResponse getPrefixPrice(PrefixPricingRequest prefixPricingRequest) throws IOException, NexmoClientException {
+    private PrefixPricingResponse getPrefixPrice(PrefixPricingRequest prefixPricingRequest) throws NexmoResponseParseException, NexmoClientException {
         return this.prefixPricing.getPrice(prefixPricingRequest);
     }
 
@@ -121,15 +116,15 @@ public class AccountClient extends AbstractClient {
      *
      * @param transaction The ID associated with your original auto-reload transaction
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response object indicating that the
-     *                              request was unsuccessful.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response object indicating
+     *                                     that the request was unsuccessful.
      */
-    public void topUp(String transaction) throws IOException, NexmoClientException {
+    public void topUp(String transaction) throws NexmoResponseParseException, NexmoClientException {
         topUp(new TopUpRequest(transaction));
     }
 
-    private void topUp(TopUpRequest request) throws IOException, NexmoClientException {
+    private void topUp(TopUpRequest request) throws NexmoResponseParseException, NexmoClientException {
         this.topUp.topUp(request);
     }
 
@@ -140,11 +135,11 @@ public class AccountClient extends AbstractClient {
      *
      * @return ListSecretsResponse object which contains the results from the API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response object indicating that the
-     *                              request was unsuccessful.
+     * @throws NexmoResponseParseException if a network error occurred contacting the Nexmo Account API
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response object indicating
+     *                                     that the request was unsuccessful.
      */
-    public ListSecretsResponse listSecrets(String apiKey) throws IOException, NexmoClientException {
+    public ListSecretsResponse listSecrets(String apiKey) throws NexmoResponseParseException, NexmoClientException {
         return this.secret.listSecrets(apiKey);
     }
 
@@ -156,15 +151,15 @@ public class AccountClient extends AbstractClient {
      *
      * @return SecretResponse object which contains the results from the API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response object indicating that the
-     *                              request was unsuccessful.
+     * @throws NexmoResponseParseException if a network error occurred contacting the Nexmo Account API
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response object indicating
+     *                                     that the request was unsuccessful.
      */
-    public SecretResponse getSecret(String apiKey, String secretId) throws IOException, NexmoClientException {
+    public SecretResponse getSecret(String apiKey, String secretId) throws NexmoResponseParseException, NexmoClientException {
         return getSecret(new SecretRequest(apiKey, secretId));
     }
 
-    private SecretResponse getSecret(SecretRequest secretRequest) throws IOException, NexmoClientException {
+    private SecretResponse getSecret(SecretRequest secretRequest) throws NexmoResponseParseException, NexmoClientException {
         return this.secret.getSecret(secretRequest);
     }
 
@@ -176,15 +171,15 @@ public class AccountClient extends AbstractClient {
      *
      * @return SecretResponse object which contains the created secret from the API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response object indicating that the
-     *                              request was unsuccessful.
+     * @throws NexmoResponseParseException if a network error occurred contacting the Nexmo Account API
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response object indicating
+     *                                     that the request was unsuccessful.
      */
-    public SecretResponse createSecret(String apiKey, String secret) throws IOException, NexmoClientException {
+    public SecretResponse createSecret(String apiKey, String secret) throws NexmoResponseParseException, NexmoClientException {
         return createSecret(new CreateSecretRequest(apiKey, secret));
     }
 
-    private SecretResponse createSecret(CreateSecretRequest createSecretRequest) throws IOException, NexmoClientException {
+    private SecretResponse createSecret(CreateSecretRequest createSecretRequest) throws NexmoResponseParseException, NexmoClientException {
         return this.secret.createSecret(createSecretRequest);
     }
 
@@ -194,15 +189,15 @@ public class AccountClient extends AbstractClient {
      * @param apiKey   The API key that the secret is associated to.
      * @param secretId The id of the secret to revoke.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response object indicating that the
-     *                              request was unsuccessful.
+     * @throws NexmoResponseParseException if a network error occurred contacting the Nexmo Account API
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response object indicating
+     *                                     that the request was unsuccessful.
      */
-    public void revokeSecret(String apiKey, String secretId) throws IOException, NexmoClientException {
+    public void revokeSecret(String apiKey, String secretId) throws NexmoResponseParseException, NexmoClientException {
         revokeSecret(new SecretRequest(apiKey, secretId));
     }
 
-    private void revokeSecret(SecretRequest secretRequest) throws IOException, NexmoClientException {
+    private void revokeSecret(SecretRequest secretRequest) throws NexmoResponseParseException, NexmoClientException {
         this.secret.revokeSecret(secretRequest);
     }
 
@@ -211,11 +206,11 @@ public class AccountClient extends AbstractClient {
      *
      * @return A {@link SettingsResponse} containing the newly-updated account settings.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response object indicating that the
-     *                              request was unsuccessful.
+     * @throws NexmoResponseParseException if a network error occurred contacting the Nexmo Account API
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response object indicating
+     *                                     that the request was unsuccessful.
      */
-    public SettingsResponse updateSmsIncomingUrl(String url) throws IOException, NexmoClientException {
+    public SettingsResponse updateSmsIncomingUrl(String url) throws NexmoResponseParseException, NexmoClientException {
         return this.updateSettings(SettingsRequest.withIncomingSmsUrl(url));
     }
 
@@ -224,11 +219,11 @@ public class AccountClient extends AbstractClient {
      *
      * @return A {@link SettingsResponse} containing the newly-updated account settings.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response object indicating that the
-     *                              request was unsuccessful.
+     * @throws NexmoResponseParseException if a network error occurred contacting the Nexmo Account API
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response object indicating
+     *                                     that the request was unsuccessful.
      */
-    public SettingsResponse updateDeliveryReceiptUrl(String url) throws IOException, NexmoClientException {
+    public SettingsResponse updateDeliveryReceiptUrl(String url) throws NexmoResponseParseException, NexmoClientException {
         return this.updateSettings(SettingsRequest.withDeliveryReceiptUrl(url));
     }
 
@@ -237,11 +232,11 @@ public class AccountClient extends AbstractClient {
      *
      * @return A {@link SettingsResponse} containing the newly-updated account settings.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Account API
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response object indicating that the
-     *                              request was unsuccessful.
+     * @throws NexmoResponseParseException if a network error occurred contacting the Nexmo Account API
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response object indicating
+     *                                     that the request was unsuccessful.
      */
-    public SettingsResponse updateSettings(SettingsRequest request) throws IOException, NexmoClientException {
+    public SettingsResponse updateSettings(SettingsRequest request) throws NexmoResponseParseException, NexmoClientException {
         return this.settings.updateSettings(request);
     }
 }

--- a/src/main/java/com/nexmo/client/account/BalanceEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/BalanceEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.account;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -48,11 +47,11 @@ class BalanceEndpoint extends AbstractMethod<Void, BalanceResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(Void request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(Void request) throws UnsupportedEncodingException {
         return RequestBuilder.get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
     }
 
-    public BalanceResponse execute() throws NexmoClientException, IOException {
+    public BalanceResponse execute() {
         return this.execute(null);
     }
 

--- a/src/main/java/com/nexmo/client/account/CreateSecretMethod.java
+++ b/src/main/java/com/nexmo/client/account/CreateSecretMethod.java
@@ -52,7 +52,7 @@ class CreateSecretMethod extends AbstractMethod<CreateSecretRequest, SecretRespo
     }
 
     @Override
-    public RequestBuilder makeRequest(CreateSecretRequest createSecretRequest) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(CreateSecretRequest createSecretRequest) throws UnsupportedEncodingException {
         if (createSecretRequest.getApiKey() == null) {
             throw new IllegalArgumentException("API key is required.");
         }
@@ -68,7 +68,7 @@ class CreateSecretMethod extends AbstractMethod<CreateSecretRequest, SecretRespo
     }
 
     @Override
-    public SecretResponse parseResponse(HttpResponse response) throws IOException, NexmoClientException {
+    public SecretResponse parseResponse(HttpResponse response) throws IOException {
         if (response.getStatusLine().getStatusCode() != 201) {
             throw new NexmoBadRequestException(EntityUtils.toString(response.getEntity()));
         }

--- a/src/main/java/com/nexmo/client/account/GetSecretMethod.java
+++ b/src/main/java/com/nexmo/client/account/GetSecretMethod.java
@@ -50,7 +50,7 @@ class GetSecretMethod extends AbstractMethod<SecretRequest, SecretResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(SecretRequest secretRequest) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(SecretRequest secretRequest) throws UnsupportedEncodingException {
         if (secretRequest.getApiKey() == null) {
             throw new IllegalArgumentException("API key is required.");
         }
@@ -68,7 +68,7 @@ class GetSecretMethod extends AbstractMethod<SecretRequest, SecretResponse> {
     }
 
     @Override
-    public SecretResponse parseResponse(HttpResponse response) throws IOException, NexmoClientException {
+    public SecretResponse parseResponse(HttpResponse response) throws IOException {
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new NexmoBadRequestException(EntityUtils.toString(response.getEntity()));
         }

--- a/src/main/java/com/nexmo/client/account/ListSecretsMethod.java
+++ b/src/main/java/com/nexmo/client/account/ListSecretsMethod.java
@@ -50,7 +50,7 @@ class ListSecretsMethod extends AbstractMethod<String, ListSecretsResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(String apiKey) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(String apiKey) throws UnsupportedEncodingException {
         if (apiKey == null) {
             throw new IllegalArgumentException("API key is required.");
         }
@@ -60,7 +60,7 @@ class ListSecretsMethod extends AbstractMethod<String, ListSecretsResponse> {
     }
 
     @Override
-    public ListSecretsResponse parseResponse(HttpResponse response) throws IOException, NexmoClientException {
+    public ListSecretsResponse parseResponse(HttpResponse response) throws IOException {
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new NexmoBadRequestException(EntityUtils.toString(response.getEntity()));
         }

--- a/src/main/java/com/nexmo/client/account/PrefixPricingEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/PrefixPricingEndpoint.java
@@ -22,9 +22,6 @@
 package com.nexmo.client.account;
 
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
 
 class PrefixPricingEndpoint {
     private PrefixPricingMethod prefixPricingMethod;
@@ -33,7 +30,7 @@ class PrefixPricingEndpoint {
         this.prefixPricingMethod = new PrefixPricingMethod(httpWrapper);
     }
 
-    PrefixPricingResponse getPrice(PrefixPricingRequest prefixPricingRequest) throws IOException, NexmoClientException {
+    PrefixPricingResponse getPrice(PrefixPricingRequest prefixPricingRequest) {
         return this.prefixPricingMethod.execute(prefixPricingRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/account/PricingEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/PricingEndpoint.java
@@ -22,9 +22,7 @@
 package com.nexmo.client.account;
 
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,7 +34,7 @@ class PricingEndpoint {
         this.methods.put(ServiceType.VOICE, new VoicePricingMethod(httpWrapper));
     }
 
-    PricingResponse getPrice(ServiceType serviceType, PricingRequest request) throws IOException, NexmoClientException {
+    PricingResponse getPrice(ServiceType serviceType, PricingRequest request) {
         if (this.methods.containsKey(serviceType)) {
             return this.methods.get(serviceType).execute(request);
         }

--- a/src/main/java/com/nexmo/client/account/RevokeSecretMethod.java
+++ b/src/main/java/com/nexmo/client/account/RevokeSecretMethod.java
@@ -49,7 +49,7 @@ class RevokeSecretMethod extends AbstractMethod<SecretRequest, Void> {
     }
 
     @Override
-    public RequestBuilder makeRequest(SecretRequest secretRequest) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(SecretRequest secretRequest) throws UnsupportedEncodingException {
         if (secretRequest.getApiKey() == null) {
             throw new IllegalArgumentException("API key is required.");
         }
@@ -67,7 +67,7 @@ class RevokeSecretMethod extends AbstractMethod<SecretRequest, Void> {
     }
 
     @Override
-    public Void parseResponse(HttpResponse response) throws IOException, NexmoClientException {
+    public Void parseResponse(HttpResponse response) throws IOException {
         if (response.getStatusLine().getStatusCode() != 204) {
             throw new NexmoBadRequestException(EntityUtils.toString(response.getEntity()));
         }

--- a/src/main/java/com/nexmo/client/account/SecretManagementEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/SecretManagementEndpoint.java
@@ -22,9 +22,6 @@
 package com.nexmo.client.account;
 
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
 
 class SecretManagementEndpoint {
     private ListSecretsMethod listSecretsMethod;
@@ -40,19 +37,19 @@ class SecretManagementEndpoint {
 
     }
 
-    ListSecretsResponse listSecrets(String apiKey) throws IOException, NexmoClientException {
+    ListSecretsResponse listSecrets(String apiKey) {
         return this.listSecretsMethod.execute(apiKey);
     }
 
-    SecretResponse getSecret(SecretRequest secretRequest) throws IOException, NexmoClientException {
+    SecretResponse getSecret(SecretRequest secretRequest) {
         return this.getSecretMethod.execute(secretRequest);
     }
 
-    SecretResponse createSecret(CreateSecretRequest createSecretRequest) throws IOException, NexmoClientException {
+    SecretResponse createSecret(CreateSecretRequest createSecretRequest) {
         return this.createSecretMethod.execute(createSecretRequest);
     }
 
-    void revokeSecret(SecretRequest secretRequest) throws IOException, NexmoClientException {
+    void revokeSecret(SecretRequest secretRequest) {
         this.revokeSecretMethod.execute(secretRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/account/SettingsEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/SettingsEndpoint.java
@@ -22,9 +22,6 @@
 package com.nexmo.client.account;
 
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
 
 class SettingsEndpoint {
     private SettingsMethod method;
@@ -33,7 +30,7 @@ class SettingsEndpoint {
         this.method = new SettingsMethod(wrapper);
     }
 
-    SettingsResponse updateSettings(SettingsRequest request) throws IOException, NexmoClientException {
+    SettingsResponse updateSettings(SettingsRequest request) {
         return this.method.execute(request);
     }
 }

--- a/src/main/java/com/nexmo/client/account/SettingsMethod.java
+++ b/src/main/java/com/nexmo/client/account/SettingsMethod.java
@@ -24,7 +24,6 @@ package com.nexmo.client.account;
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoBadRequestException;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -49,7 +48,7 @@ class SettingsMethod extends AbstractMethod<SettingsRequest, SettingsResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(SettingsRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(SettingsRequest request) throws UnsupportedEncodingException {
         return RequestBuilder
                 .post(httpWrapper.getHttpConfig().getRestBaseUri() + PATH)
                 .addParameter("moCallBackUrl", request.getIncomingSmsUrl())
@@ -57,7 +56,7 @@ class SettingsMethod extends AbstractMethod<SettingsRequest, SettingsResponse> {
     }
 
     @Override
-    public SettingsResponse parseResponse(HttpResponse response) throws IOException, NexmoClientException {
+    public SettingsResponse parseResponse(HttpResponse response) throws IOException {
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new NexmoBadRequestException(EntityUtils.toString(response.getEntity()));
         }

--- a/src/main/java/com/nexmo/client/account/TopUpEndpoint.java
+++ b/src/main/java/com/nexmo/client/account/TopUpEndpoint.java
@@ -22,9 +22,6 @@
 package com.nexmo.client.account;
 
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
 
 class TopUpEndpoint {
     private TopUpMethod topUpMethod;
@@ -33,7 +30,7 @@ class TopUpEndpoint {
         this.topUpMethod = new TopUpMethod(httpWrapper);
     }
 
-    void topUp(TopUpRequest request) throws IOException, NexmoClientException {
+    void topUp(TopUpRequest request) {
         this.topUpMethod.execute(request);
     }
 }

--- a/src/main/java/com/nexmo/client/account/TopUpMethod.java
+++ b/src/main/java/com/nexmo/client/account/TopUpMethod.java
@@ -48,7 +48,7 @@ class TopUpMethod extends AbstractMethod<TopUpRequest, Void> {
     }
 
     @Override
-    public RequestBuilder makeRequest(TopUpRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(TopUpRequest request) throws UnsupportedEncodingException {
         return RequestBuilder
                 .get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH)
                 .addParameter("trx", request.getTrx());

--- a/src/main/java/com/nexmo/client/application/ApplicationClient.java
+++ b/src/main/java/com/nexmo/client/application/ApplicationClient.java
@@ -21,12 +21,7 @@
  */
 package com.nexmo.client.application;
 
-import com.nexmo.client.AbstractClient;
-import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClient;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
+import com.nexmo.client.*;
 
 /**
  * A client for talking to the Nexmo Application API. The standard way to obtain an instance of this class is to use
@@ -47,10 +42,10 @@ public class ApplicationClient extends AbstractClient {
      *
      * @return The application which has been created.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Application API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request.
      */
-    public Application createApplication(Application application) throws IOException, NexmoClientException {
+    public Application createApplication(Application application) throws NexmoResponseParseException, NexmoClientException {
         return this.applicationEndpoint.create(application);
     }
 
@@ -61,10 +56,10 @@ public class ApplicationClient extends AbstractClient {
      *
      * @return The application which has been updated.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Application API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request.
      */
-    public Application updateApplication(Application application) throws IOException, NexmoClientException {
+    public Application updateApplication(Application application) throws NexmoResponseParseException, NexmoClientException {
         return this.applicationEndpoint.update(application);
     }
 
@@ -75,10 +70,10 @@ public class ApplicationClient extends AbstractClient {
      *
      * @return The corresponding application.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Application API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request.
      */
-    public Application getApplication(String id) throws IOException, NexmoClientException {
+    public Application getApplication(String id) throws NexmoResponseParseException, NexmoClientException {
         return this.applicationEndpoint.get(id);
     }
 
@@ -87,10 +82,10 @@ public class ApplicationClient extends AbstractClient {
      *
      * @param id The id of the application to delete.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Application API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request.
      */
-    public void deleteApplication(String id) throws IOException, NexmoClientException {
+    public void deleteApplication(String id) throws NexmoResponseParseException, NexmoClientException {
         this.applicationEndpoint.delete(id);
     }
 
@@ -99,10 +94,10 @@ public class ApplicationClient extends AbstractClient {
      *
      * @return The list of available applications.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Application API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request.
      */
-    public ApplicationList listApplications() throws IOException, NexmoClientException {
+    public ApplicationList listApplications() throws NexmoResponseParseException, NexmoClientException {
         return listApplications(null);
     }
 
@@ -113,10 +108,10 @@ public class ApplicationClient extends AbstractClient {
      *
      * @return The list of available applications.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Application API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request.
      */
-    public ApplicationList listApplications(ListApplicationRequest listApplicationRequest) throws IOException, NexmoClientException {
+    public ApplicationList listApplications(ListApplicationRequest listApplicationRequest) throws NexmoResponseParseException, NexmoClientException {
         return this.applicationEndpoint.list(listApplicationRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/application/ApplicationEndpoint.java
+++ b/src/main/java/com/nexmo/client/application/ApplicationEndpoint.java
@@ -22,9 +22,6 @@
 package com.nexmo.client.application;
 
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
 
 class ApplicationEndpoint {
     private CreateApplicationMethod createApplicationMethod;
@@ -41,23 +38,23 @@ class ApplicationEndpoint {
         this.listApplicationsMethod = new ListApplicationsMethod(httpWrapper);
     }
 
-    Application create(Application application) throws IOException, NexmoClientException {
+    Application create(Application application) {
         return this.createApplicationMethod.execute(application);
     }
 
-    Application update(Application application) throws IOException, NexmoClientException {
+    Application update(Application application) {
         return this.updateApplicationMethod.execute(application);
     }
 
-    Application get(String id) throws IOException, NexmoClientException {
+    Application get(String id) {
         return this.getApplicationMethod.execute(id);
     }
 
-    void delete(String id) throws IOException, NexmoClientException {
+    void delete(String id) {
         this.deleteApplicationMethod.execute(id);
     }
 
-    public ApplicationList list(ListApplicationRequest request) throws IOException, NexmoClientException {
+    ApplicationList list(ListApplicationRequest request) {
         return this.listApplicationsMethod.execute(request);
     }
 }

--- a/src/main/java/com/nexmo/client/application/CreateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/application/CreateApplicationMethod.java
@@ -50,7 +50,7 @@ class CreateApplicationMethod extends AbstractMethod<Application, Application> {
     }
 
     @Override
-    public RequestBuilder makeRequest(Application application) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(Application application) throws UnsupportedEncodingException {
         return RequestBuilder
                 .post(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v2") + PATH)
                 .setHeader("Content-Type", "application/json")

--- a/src/main/java/com/nexmo/client/application/DeleteApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/application/DeleteApplicationMethod.java
@@ -48,7 +48,7 @@ class DeleteApplicationMethod extends AbstractMethod<String, Void> {
     }
 
     @Override
-    public RequestBuilder makeRequest(String id) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(String id) throws UnsupportedEncodingException {
         return RequestBuilder
                 .delete(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v2") + String.format(PATH, id))
                 .setHeader("Content-Type", "application/json");

--- a/src/main/java/com/nexmo/client/application/GetApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/application/GetApplicationMethod.java
@@ -49,7 +49,7 @@ class GetApplicationMethod extends AbstractMethod<String, Application> {
     }
 
     @Override
-    public RequestBuilder makeRequest(String id) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(String id) throws UnsupportedEncodingException {
         return RequestBuilder
                 .get(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v2") + String.format(PATH, id))
                 .setHeader("Content-Type", "application/json");

--- a/src/main/java/com/nexmo/client/application/ListApplicationsMethod.java
+++ b/src/main/java/com/nexmo/client/application/ListApplicationsMethod.java
@@ -49,7 +49,7 @@ class ListApplicationsMethod extends AbstractMethod<ListApplicationRequest, Appl
     }
 
     @Override
-    public RequestBuilder makeRequest(ListApplicationRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(ListApplicationRequest request) throws UnsupportedEncodingException {
         RequestBuilder builder = RequestBuilder
                 .get(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v2") + PATH)
                 .setHeader("Content-Type", "application/json");

--- a/src/main/java/com/nexmo/client/application/UpdateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/application/UpdateApplicationMethod.java
@@ -50,7 +50,7 @@ class UpdateApplicationMethod extends AbstractMethod<Application, Application> {
     }
 
     @Override
-    public RequestBuilder makeRequest(Application application) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(Application application) throws UnsupportedEncodingException {
         return RequestBuilder
                 .put(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v2") + String.format(PATH, application.getId()))
                 .setHeader("Content-Type", "application/json")

--- a/src/main/java/com/nexmo/client/conversion/ConversionClient.java
+++ b/src/main/java/com/nexmo/client/conversion/ConversionClient.java
@@ -21,12 +21,8 @@
  */
 package com.nexmo.client.conversion;
 
-import com.nexmo.client.AbstractClient;
-import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClient;
-import com.nexmo.client.NexmoClientException;
+import com.nexmo.client.*;
 
-import java.io.IOException;
 import java.util.Date;
 
 /**
@@ -54,13 +50,14 @@ public class ConversionClient extends AbstractClient {
      * @param messageId The id of the message that was sent.
      * @param delivered A boolean indicating whether or not it was delivered.
      * @param timestamp A timestamp of when it was known to be delivered.
-     * @throws IOException          if a network error occurred contacting the Nexmo Conversion API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public void submitConversion(ConversionRequest.Type type,
                                  String messageId,
                                  boolean delivered,
-                                 Date timestamp) throws IOException, NexmoClientException {
+                                 Date timestamp) throws NexmoResponseParseException, NexmoClientException {
         this.conversionEndpoint.submitConversion(new ConversionRequest(type, messageId, delivered, timestamp));
     }
 }

--- a/src/main/java/com/nexmo/client/conversion/ConversionEndpoint.java
+++ b/src/main/java/com/nexmo/client/conversion/ConversionEndpoint.java
@@ -24,8 +24,6 @@ package com.nexmo.client.conversion;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClientException;
 
-import java.io.IOException;
-
 class ConversionEndpoint {
     private ConversionMethod conversionMethod;
 
@@ -33,7 +31,7 @@ class ConversionEndpoint {
         this.conversionMethod = new ConversionMethod(httpWrapper);
     }
 
-    void submitConversion(ConversionRequest request) throws IOException, NexmoClientException {
+    void submitConversion(ConversionRequest request) throws NexmoClientException {
         this.conversionMethod.execute(request);
     }
 }

--- a/src/main/java/com/nexmo/client/conversion/ConversionMethod.java
+++ b/src/main/java/com/nexmo/client/conversion/ConversionMethod.java
@@ -51,7 +51,7 @@ class ConversionMethod extends AbstractMethod<ConversionRequest, Void> {
     }
 
     @Override
-    public RequestBuilder makeRequest(ConversionRequest conversionRequest) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(ConversionRequest conversionRequest) throws UnsupportedEncodingException {
         String uri =
                 httpWrapper.getHttpConfig().getApiBaseUri() + PATH + conversionRequest.getType().name().toLowerCase();
         return RequestBuilder

--- a/src/main/java/com/nexmo/client/insight/AdvancedInsightEndpoint.java
+++ b/src/main/java/com/nexmo/client/insight/AdvancedInsightEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.insight;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
@@ -48,7 +47,7 @@ class AdvancedInsightEndpoint extends AbstractMethod<AdvancedInsightRequest, Adv
     }
 
     @Override
-    public RequestBuilder makeRequest(AdvancedInsightRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(AdvancedInsightRequest request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder
                 .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
                 .addParameter("number", request.getNumber());

--- a/src/main/java/com/nexmo/client/insight/BasicInsightEndpoint.java
+++ b/src/main/java/com/nexmo/client/insight/BasicInsightEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.insight;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
@@ -49,7 +48,7 @@ class BasicInsightEndpoint extends AbstractMethod<BasicInsightRequest, BasicInsi
     }
 
     @Override
-    public RequestBuilder makeRequest(BasicInsightRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(BasicInsightRequest request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder
                 .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
                 .addParameter("number", request.getNumber());

--- a/src/main/java/com/nexmo/client/insight/InsightClient.java
+++ b/src/main/java/com/nexmo/client/insight/InsightClient.java
@@ -21,12 +21,7 @@
  */
 package com.nexmo.client.insight;
 
-import com.nexmo.client.AbstractClient;
-import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClient;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
+import com.nexmo.client.*;
 
 /**
  * A client for talking to the Nexmo Number Insight API. The standard way to obtain an instance of this class is to use
@@ -57,10 +52,10 @@ public class InsightClient extends AbstractClient {
      *
      * @return A {@link BasicInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public BasicInsightResponse getBasicNumberInsight(String number) throws IOException, NexmoClientException {
+    public BasicInsightResponse getBasicNumberInsight(String number) throws NexmoResponseParseException, NexmoClientException {
         return getBasicNumberInsight(BasicInsightRequest.withNumber(number));
     }
 
@@ -72,10 +67,10 @@ public class InsightClient extends AbstractClient {
      *
      * @return A {@link BasicInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public BasicInsightResponse getBasicNumberInsight(String number, String country) throws IOException, NexmoClientException {
+    public BasicInsightResponse getBasicNumberInsight(String number, String country) throws NexmoResponseParseException, NexmoClientException {
         return getBasicNumberInsight(BasicInsightRequest.withNumberAndCountry(number, country));
     }
 
@@ -86,10 +81,10 @@ public class InsightClient extends AbstractClient {
      *
      * @return A {@link BasicInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public BasicInsightResponse getBasicNumberInsight(BasicInsightRequest basicInsightRequest) throws IOException, NexmoClientException {
+    public BasicInsightResponse getBasicNumberInsight(BasicInsightRequest basicInsightRequest) throws NexmoResponseParseException, NexmoClientException {
         return this.basic.execute(basicInsightRequest);
     }
 
@@ -100,10 +95,10 @@ public class InsightClient extends AbstractClient {
      *
      * @return A {@link StandardInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public StandardInsightResponse getStandardNumberInsight(String number) throws IOException, NexmoClientException {
+    public StandardInsightResponse getStandardNumberInsight(String number) throws NexmoResponseParseException, NexmoClientException {
         return getStandardNumberInsight(StandardInsightRequest.withNumber(number));
     }
 
@@ -115,10 +110,10 @@ public class InsightClient extends AbstractClient {
      *
      * @return A {@link StandardInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public StandardInsightResponse getStandardNumberInsight(String number, String country) throws IOException, NexmoClientException {
+    public StandardInsightResponse getStandardNumberInsight(String number, String country) throws NexmoResponseParseException, NexmoClientException {
         return getStandardNumberInsight(StandardInsightRequest.withNumberAndCountry(number, country));
     }
 
@@ -127,18 +122,18 @@ public class InsightClient extends AbstractClient {
      *
      * @param number  A single phone number that you need insight about in national or international format.
      * @param country If a number does not have a country code or it is uncertain, set the two-character country code.
-     * @param cnam    Indicates if the name of the person who owns the phone number should also be looked up and returned.
-     *                Set to true to receive phone number owner name in the response. This is only available for US numbers
-     *                and incurs an additional charge.
+     * @param cnam    Indicates if the name of the person who owns the phone number should also be looked up and
+     *                returned. Set to true to receive phone number owner name in the response. This is only available
+     *                for US numbers and incurs an additional charge.
      *
      * @return A {@link StandardInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      * @deprecated Create a {@link StandardInsightRequest} and use {@link InsightClient#getStandardNumberInsight(StandardInsightRequest)}
      */
     @Deprecated
-    public StandardInsightResponse getStandardNumberInsight(String number, String country, boolean cnam) throws IOException, NexmoClientException {
+    public StandardInsightResponse getStandardNumberInsight(String number, String country, boolean cnam) throws NexmoResponseParseException, NexmoClientException {
         return getStandardNumberInsight(StandardInsightRequest.builder(number).country(country).cnam(cnam).build());
     }
 
@@ -149,10 +144,10 @@ public class InsightClient extends AbstractClient {
      *
      * @return A {@link StandardInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public StandardInsightResponse getStandardNumberInsight(StandardInsightRequest standardInsightRequest) throws IOException, NexmoClientException {
+    public StandardInsightResponse getStandardNumberInsight(StandardInsightRequest standardInsightRequest) throws NexmoResponseParseException, NexmoClientException {
         return this.standard.execute(standardInsightRequest);
     }
 
@@ -163,10 +158,10 @@ public class InsightClient extends AbstractClient {
      *
      * @return A {@link AdvancedInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public AdvancedInsightResponse getAdvancedNumberInsight(String number) throws IOException, NexmoClientException {
+    public AdvancedInsightResponse getAdvancedNumberInsight(String number) throws NexmoResponseParseException, NexmoClientException {
         return getAdvancedNumberInsight(AdvancedInsightRequest.withNumber(number));
     }
 
@@ -178,10 +173,10 @@ public class InsightClient extends AbstractClient {
      *
      * @return A {@link AdvancedInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public AdvancedInsightResponse getAdvancedNumberInsight(String number, String country) throws IOException, NexmoClientException {
+    public AdvancedInsightResponse getAdvancedNumberInsight(String number, String country) throws NexmoResponseParseException, NexmoClientException {
         return getAdvancedNumberInsight(AdvancedInsightRequest.withNumberAndCountry(number, country));
     }
 
@@ -189,18 +184,19 @@ public class InsightClient extends AbstractClient {
      * Perform an Advanced Insight Request with a number, country, and ipAddress.
      *
      * @param number    A single phone number that you need insight about in national or international format.
-     * @param country   If a number does not have a country code or it is uncertain, set the two-character country code.
-     * @param ipAddress The IP address of the user. If supplied, we will compare this to the country the user's phone
-     *                  is located in and return an error if it does not match.
+     * @param country   If a number does not have a country code or it is uncertain, set the two-character country
+     *                  code.
+     * @param ipAddress The IP address of the user. If supplied, we will compare this to the country the user's phone is
+     *                  located in and return an error if it does not match.
      *
      * @return A {@link AdvancedInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      * @deprecated Create a {@link AdvancedInsightRequest} and use {@link InsightClient#getAdvancedNumberInsight(AdvancedInsightRequest)}
      */
     @Deprecated
-    public AdvancedInsightResponse getAdvancedNumberInsight(String number, String country, String ipAddress) throws IOException, NexmoClientException {
+    public AdvancedInsightResponse getAdvancedNumberInsight(String number, String country, String ipAddress) throws NexmoResponseParseException, NexmoClientException {
         return getAdvancedNumberInsight(AdvancedInsightRequest.builder(number)
                 .country(country)
                 .ipAddress(ipAddress)
@@ -211,21 +207,22 @@ public class InsightClient extends AbstractClient {
      * Perform an Advanced Insight Request with a number, country, ipAddress, and cnam.
      *
      * @param number    A single phone number that you need insight about in national or international format.
-     * @param country   If a number does not have a country code or it is uncertain, set the two-character country code.
-     * @param ipAddress The IP address of the user. If supplied, we will compare this to the country the user's phone
-     *                  is located in and return an error if it does not match.
-     * @param cnam      Indicates if the name of the person who owns the phone number should also be looked up and returned.
-     *                  Set to true to receive phone number owner name in the response. This is only available for US numbers
-     *                  and incurs an additional charge.
+     * @param country   If a number does not have a country code or it is uncertain, set the two-character country
+     *                  code.
+     * @param ipAddress The IP address of the user. If supplied, we will compare this to the country the user's phone is
+     *                  located in and return an error if it does not match.
+     * @param cnam      Indicates if the name of the person who owns the phone number should also be looked up and
+     *                  returned. Set to true to receive phone number owner name in the response. This is only available
+     *                  for US numbers and incurs an additional charge.
      *
      * @return A {@link AdvancedInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      * @deprecated Create a {@link AdvancedInsightRequest} and use {@link InsightClient#getAdvancedNumberInsight(AdvancedInsightRequest)}
      */
     @Deprecated
-    public AdvancedInsightResponse getAdvancedNumberInsight(String number, String country, String ipAddress, boolean cnam) throws IOException, NexmoClientException {
+    public AdvancedInsightResponse getAdvancedNumberInsight(String number, String country, String ipAddress, boolean cnam) throws NexmoResponseParseException, NexmoClientException {
         return getAdvancedNumberInsight(AdvancedInsightRequest.builder(number)
                 .country(country)
                 .ipAddress(ipAddress)
@@ -240,10 +237,10 @@ public class InsightClient extends AbstractClient {
      *
      * @return A {@link AdvancedInsightResponse} representing the response from the Nexmo Number Insight API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Nexmo Number Insight API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
      */
-    public AdvancedInsightResponse getAdvancedNumberInsight(AdvancedInsightRequest advancedInsightRequest) throws IOException, NexmoClientException {
+    public AdvancedInsightResponse getAdvancedNumberInsight(AdvancedInsightRequest advancedInsightRequest) throws NexmoResponseParseException, NexmoClientException {
         return this.advanced.execute(advancedInsightRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/insight/StandardInsightEndpoint.java
+++ b/src/main/java/com/nexmo/client/insight/StandardInsightEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.insight;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
@@ -48,7 +47,7 @@ class StandardInsightEndpoint extends AbstractMethod<StandardInsightRequest, Sta
     }
 
     @Override
-    public RequestBuilder makeRequest(StandardInsightRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(StandardInsightRequest request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder
                 .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
                 .addParameter("number", request.getNumber());

--- a/src/main/java/com/nexmo/client/numbers/BuyNumberEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/BuyNumberEndpoint.java
@@ -47,7 +47,7 @@ class BuyNumberEndpoint extends AbstractMethod<BuyNumberRequest, Void> {
     }
 
     @Override
-    public RequestBuilder makeRequest(BuyNumberRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(BuyNumberRequest request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder
                 .post()
                 .setUri(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);

--- a/src/main/java/com/nexmo/client/numbers/CancelNumberEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/CancelNumberEndpoint.java
@@ -25,7 +25,6 @@ package com.nexmo.client.numbers;
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoBadRequestException;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -48,7 +47,7 @@ class CancelNumberEndpoint extends AbstractMethod<CancelNumberRequest, Void> {
     }
 
     @Override
-    public RequestBuilder makeRequest(CancelNumberRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(CancelNumberRequest request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder
                 .post()
                 .setUri(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
@@ -57,7 +56,7 @@ class CancelNumberEndpoint extends AbstractMethod<CancelNumberRequest, Void> {
     }
 
     @Override
-    public Void parseResponse(HttpResponse response) throws NexmoClientException, IOException {
+    public Void parseResponse(HttpResponse response) throws IOException {
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new NexmoBadRequestException(EntityUtils.toString(response.getEntity()));
         }

--- a/src/main/java/com/nexmo/client/numbers/ListNumbersEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/ListNumbersEndpoint.java
@@ -47,7 +47,7 @@ class ListNumbersEndpoint extends AbstractMethod<ListNumbersFilter, ListNumbersR
     }
 
     @Override
-    public RequestBuilder makeRequest(ListNumbersFilter request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(ListNumbersFilter request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder
                 .get()
                 .setUri(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
@@ -61,7 +61,7 @@ class ListNumbersEndpoint extends AbstractMethod<ListNumbersFilter, ListNumbersR
         return ListNumbersResponse.fromJson(json);
     }
 
-    ListNumbersResponse listNumbers(ListNumbersFilter request) throws IOException, NexmoClientException {
+    ListNumbersResponse listNumbers(ListNumbersFilter request) throws NexmoClientException {
         return this.execute(request);
     }
 }

--- a/src/main/java/com/nexmo/client/numbers/NumbersClient.java
+++ b/src/main/java/com/nexmo/client/numbers/NumbersClient.java
@@ -24,8 +24,7 @@ package com.nexmo.client.numbers;
 
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
+import com.nexmo.client.NexmoResponseParseException;
 
 /**
  * A client for accessing the Nexmo API calls that manage phone numbers.
@@ -49,10 +48,11 @@ public class NumbersClient {
      * Get the first page of phone numbers assigned to the authenticated account.
      *
      * @return A ListNumbersResponse containing the first 10 phone numbers
-     * @throws IOException          if an error occurs contacting the Nexmo API
-     * @throws NexmoClientException if an error is returned by the server.
+     *
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if an error is returned by the server.
      */
-    public ListNumbersResponse listNumbers() throws IOException, NexmoClientException {
+    public ListNumbersResponse listNumbers() throws NexmoResponseParseException, NexmoClientException {
         return this.listNumbers.listNumbers(new ListNumbersFilter());
     }
 
@@ -60,11 +60,13 @@ public class NumbersClient {
      * Get a filtered set of numbers assigned to the authenticated account.
      *
      * @param filter A ListNumbersFilter describing the filters to be applied to the request.
+     *
      * @return A ListNumbersResponse containing phone numbers matching the supplied filter.
-     * @throws IOException          if an error occurs contacting the Nexmo API
-     * @throws NexmoClientException if an error is returned by the server.
+     *
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if an error is returned by the server.
      */
-    public ListNumbersResponse listNumbers(ListNumbersFilter filter) throws IOException, NexmoClientException {
+    public ListNumbersResponse listNumbers(ListNumbersFilter filter) throws NexmoResponseParseException, NexmoClientException {
         return this.listNumbers.listNumbers(filter);
     }
 
@@ -72,20 +74,20 @@ public class NumbersClient {
     /**
      * Search for available Nexmo Virtual Numbers.
      *
-     * @throws IOException          if an error occurs contacting the Nexmo API
-     * @throws NexmoClientException if an error is returned by the server.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if an error is returned by the server.
      */
-    public SearchNumbersResponse searchNumbers(String country) throws IOException, NexmoClientException {
+    public SearchNumbersResponse searchNumbers(String country) throws NexmoResponseParseException, NexmoClientException {
         return this.searchNumbers(new SearchNumbersFilter(country));
     }
 
     /**
      * Search for available Nexmo Virtual Numbers.
      *
-     * @throws IOException          if an error occurs contacting the Nexmo API
-     * @throws NexmoClientException if an error is returned by the server.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if an error is returned by the server.
      */
-    public SearchNumbersResponse searchNumbers(SearchNumbersFilter filter) throws IOException, NexmoClientException {
+    public SearchNumbersResponse searchNumbers(SearchNumbersFilter filter) throws NexmoResponseParseException, NexmoClientException {
         return this.searchNumbers.searchNumbers(filter);
     }
 
@@ -94,10 +96,11 @@ public class NumbersClient {
      *
      * @param country A String containing a 2-character ISO country code.
      * @param msisdn  The phone number to be bought.
-     * @throws IOException          if an error occurs contacting the Nexmo API
-     * @throws NexmoClientException if an error is returned by the server.
+     *
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if an error is returned by the server.
      */
-    public void buyNumber(String country, String msisdn) throws IOException, NexmoClientException {
+    public void buyNumber(String country, String msisdn) throws NexmoResponseParseException, NexmoClientException {
         this.buyNumber.execute(new BuyNumberRequest(country, msisdn));
     }
 
@@ -106,10 +109,11 @@ public class NumbersClient {
      *
      * @param country A String containing a 2-character ISO country code.
      * @param msisdn  The phone number to be cancelled.
-     * @throws IOException          if an error occurs contacting the Nexmo API
-     * @throws NexmoClientException if an error is returned by the server.
+     *
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if an error is returned by the server.
      */
-    public void cancelNumber(String country, String msisdn) throws IOException, NexmoClientException {
+    public void cancelNumber(String country, String msisdn) throws NexmoResponseParseException, NexmoClientException {
         this.cancelNumber.execute(new CancelNumberRequest(country, msisdn));
     }
 
@@ -117,10 +121,11 @@ public class NumbersClient {
      * Update the callbacks and/or application associations for a given Nexmo Virtual Number.
      *
      * @param request Details of the updates to be made to the number association.
-     * @throws IOException          if an error occurs contacting the Nexmo API
-     * @throws NexmoClientException if an error is returned by the server.
+     *
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if an error is returned by the server.
      */
-    public void updateNumber(UpdateNumberRequest request) throws IOException, NexmoClientException {
+    public void updateNumber(UpdateNumberRequest request) throws NexmoResponseParseException, NexmoClientException {
         this.updateNumber.execute(request);
     }
 
@@ -130,10 +135,11 @@ public class NumbersClient {
      * @param msisdn  The Nexmo Virtual Number to be updated.
      * @param country The country for the given msisdn.
      * @param appId   The ID for the Nexmo Application to be associated with the number.
-     * @throws IOException          if an error occurs contacting the Nexmo API
-     * @throws NexmoClientException if an error is returned by the server.
+     *
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
+     * @throws NexmoClientException        if an error is returned by the server.
      */
-    public void linkNumber(String msisdn, String country, String appId) throws IOException, NexmoClientException {
+    public void linkNumber(String msisdn, String country, String appId) throws NexmoResponseParseException, NexmoClientException {
         UpdateNumberRequest request = new UpdateNumberRequest(msisdn, country);
         request.setVoiceCallbackType(UpdateNumberRequest.CallbackType.APP);
         request.setVoiceCallbackValue(appId);

--- a/src/main/java/com/nexmo/client/numbers/SearchNumbersEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/SearchNumbersEndpoint.java
@@ -24,7 +24,6 @@ package com.nexmo.client.numbers;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -33,11 +32,6 @@ import org.apache.http.impl.client.BasicResponseHandler;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
-/**
- * Internal class, representing the Nexmo API endpoint which can be used to search for available virtual numbers to buy.
- * <p>
- * Use {@link NumbersClient#searchNumbers} instead of this class directly.
- */
 class SearchNumbersEndpoint extends AbstractMethod<SearchNumbersFilter, SearchNumbersResponse> {
     private static final String PATH = "/number/search";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
@@ -52,7 +46,7 @@ class SearchNumbersEndpoint extends AbstractMethod<SearchNumbersFilter, SearchNu
     }
 
     @Override
-    public RequestBuilder makeRequest(SearchNumbersFilter request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(SearchNumbersFilter request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder
                 .get()
                 .setUri(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
@@ -66,7 +60,7 @@ class SearchNumbersEndpoint extends AbstractMethod<SearchNumbersFilter, SearchNu
         return SearchNumbersResponse.fromJson(json);
     }
 
-    SearchNumbersResponse searchNumbers(SearchNumbersFilter request) throws IOException, NexmoClientException {
+    SearchNumbersResponse searchNumbers(SearchNumbersFilter request) {
         return this.execute(request);
     }
 }

--- a/src/main/java/com/nexmo/client/numbers/UpdateNumberEndpoint.java
+++ b/src/main/java/com/nexmo/client/numbers/UpdateNumberEndpoint.java
@@ -49,7 +49,7 @@ class UpdateNumberEndpoint extends AbstractMethod<UpdateNumberRequest, Void> {
     }
 
     @Override
-    public RequestBuilder makeRequest(UpdateNumberRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(UpdateNumberRequest request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder.post(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;

--- a/src/main/java/com/nexmo/client/redact/RedactClient.java
+++ b/src/main/java/com/nexmo/client/redact/RedactClient.java
@@ -21,16 +21,11 @@
  */
 package com.nexmo.client.redact;
 
-import com.nexmo.client.AbstractClient;
-import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClient;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
+import com.nexmo.client.*;
 
 /**
- * A client for talking to the Nexmo Redact API. The standard way to obtain an instance of this class is to use
- * {@link NexmoClient#getRedactClient()}.
+ * A client for talking to the Nexmo Redact API. The standard way to obtain an instance of this class is to use {@link
+ * NexmoClient#getRedactClient()}.
  */
 public class RedactClient extends AbstractClient {
     private RedactEndpoint redactEndpoint;
@@ -47,10 +42,10 @@ public class RedactClient extends AbstractClient {
      * @param id      The transaction id to redact.
      * @param product The {@link com.nexmo.client.redact.RedactRequest.Product} which corresponds to the transaction.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Redact API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public void redactTransaction(String id, RedactRequest.Product product) throws IOException, NexmoClientException {
+    public void redactTransaction(String id, RedactRequest.Product product) throws NexmoResponseParseException, NexmoClientException {
         this.redactTransaction(new RedactRequest(id, product));
     }
 
@@ -61,10 +56,10 @@ public class RedactClient extends AbstractClient {
      * @param product The {@link com.nexmo.client.redact.RedactRequest.Product} which corresponds to the transaction.
      * @param type    The {@link com.nexmo.client.redact.RedactRequest.Type} which is required if redacting SMS data.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Redact API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public void redactTransaction(String id, RedactRequest.Product product, RedactRequest.Type type) throws IOException, NexmoClientException {
+    public void redactTransaction(String id, RedactRequest.Product product, RedactRequest.Type type) throws NexmoResponseParseException, NexmoClientException {
         RedactRequest request = new RedactRequest(id, product);
         request.setType(type);
 
@@ -76,10 +71,10 @@ public class RedactClient extends AbstractClient {
      *
      * @param redactRequest a {@link RedactRequest} object which contains the request parameters.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Redact API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public void redactTransaction(RedactRequest redactRequest) throws IOException, NexmoClientException {
+    public void redactTransaction(RedactRequest redactRequest) throws NexmoResponseParseException, NexmoClientException {
         this.redactEndpoint.redactTransaction(redactRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/redact/RedactEndpoint.java
+++ b/src/main/java/com/nexmo/client/redact/RedactEndpoint.java
@@ -24,8 +24,6 @@ package com.nexmo.client.redact;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClientException;
 
-import java.io.IOException;
-
 class RedactEndpoint {
     private RedactMethod redactMethod;
 
@@ -33,7 +31,7 @@ class RedactEndpoint {
         this.redactMethod = new RedactMethod(httpWrapper);
     }
 
-    void redactTransaction(RedactRequest redactRequest) throws IOException, NexmoClientException {
+    void redactTransaction(RedactRequest redactRequest) throws NexmoClientException {
         this.redactMethod.execute(redactRequest);
     }
 }

--- a/src/main/java/com/nexmo/client/redact/RedactMethod.java
+++ b/src/main/java/com/nexmo/client/redact/RedactMethod.java
@@ -51,7 +51,7 @@ class RedactMethod extends AbstractMethod<RedactRequest, RedactResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(RedactRequest redactRequest) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(RedactRequest redactRequest) throws UnsupportedEncodingException {
         if (redactRequest.getId() == null || redactRequest.getProduct() == null) {
             throw new IllegalArgumentException("Redact transaction id and product are required.");
         }

--- a/src/main/java/com/nexmo/client/sms/SearchRejectedMessagesEndpoint.java
+++ b/src/main/java/com/nexmo/client/sms/SearchRejectedMessagesEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.sms;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -48,7 +47,7 @@ public class SearchRejectedMessagesEndpoint extends AbstractMethod<SearchRejecte
     }
 
     @Override
-    public RequestBuilder makeRequest(SearchRejectedMessagesRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(SearchRejectedMessagesRequest request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;

--- a/src/main/java/com/nexmo/client/sms/SendMessageEndpoint.java
+++ b/src/main/java/com/nexmo/client/sms/SendMessageEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.sms;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
 import com.nexmo.client.sms.messages.Message;
@@ -50,7 +49,7 @@ class SendMessageEndpoint extends AbstractMethod<Message, SmsSubmissionResponse>
     }
 
     @Override
-    public RequestBuilder makeRequest(Message message) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(Message message) throws UnsupportedEncodingException {
         RequestBuilder request = RequestBuilder.post(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         message.addParams(request);
         return request;

--- a/src/main/java/com/nexmo/client/sms/SmsClient.java
+++ b/src/main/java/com/nexmo/client/sms/SmsClient.java
@@ -28,7 +28,6 @@ import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.NexmoResponseParseException;
 import com.nexmo.client.sms.messages.Message;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -36,8 +35,8 @@ import java.util.List;
 
 
 /**
- * A client for talking to the Nexmo Voice API. The standard way to obtain an instance of this class is to use
- * {@link NexmoClient#getSmsClient()}.
+ * A client for talking to the Nexmo Voice API. The standard way to obtain an instance of this class is to use {@link
+ * NexmoClient#getSmsClient()}.
  */
 public class SmsClient {
     private SendMessageEndpoint message;
@@ -58,33 +57,39 @@ public class SmsClient {
     /**
      * Send an SMS message.
      * <p>
-     * This uses the supplied object to construct a request and post it to the Nexmo API.<br>
-     * This method will respond with an SmsSubmissionResponse object. Depending on the nature and length of the submitted message, Nexmo may automatically
-     * split the message into multiple sms messages in order to deliver to the handset. For example, a long text sms of greater than 160 chars will need to be split
-     * into multiple 'concatenated' sms messages. The Nexmo service will handle this automatically for you.<br>
-     * The messages are stored as a Collection of SmsSubmissionResponseMessage objects on the SmsSubmissionResponse object.
-     * Each message can potentially have a different status result, and each message will have a different message id.
-     * Delivery notifications will be generated for each sms message within this set and will be posted to your application containing
-     * the appropriate message id.
+     * This uses the supplied object to construct a request and post it to the Nexmo API.<br> This method will respond
+     * with an SmsSubmissionResponse object. Depending on the nature and length of the submitted message, Nexmo may
+     * automatically split the message into multiple sms messages in order to deliver to the handset. For example, a
+     * long text sms of greater than 160 chars will need to be split into multiple 'concatenated' sms messages. The
+     * Nexmo service will handle this automatically for you.<br> The messages are stored as a Collection of
+     * SmsSubmissionResponseMessage objects on the SmsSubmissionResponse object. Each message can potentially have a
+     * different status result, and each message will have a different message id. Delivery notifications will be
+     * generated for each sms message within this set and will be posted to your application containing the appropriate
+     * message id.
      *
      * @param message The message request object that describes the type of message and the contents to be submitted.
      *
-     * @return SmsSubmissionResponse an object containing a collection of SmsSubmissionResponseMessage objects for each actual sms that was required to submit the message.
+     * @return SmsSubmissionResponse an object containing a collection of SmsSubmissionResponseMessage objects for each
+     * actual sms that was required to submit the message.
      *
-     * @throws NexmoResponseParseException if the HTTP response could not be parsed.
-     * @throws IOException                 There has been an error attempting to communicate with the Nexmo service (e.g. Network failure).
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public SmsSubmissionResponse submitMessage(Message message) throws IOException, NexmoClientException {
+    public SmsSubmissionResponse submitMessage(Message message) throws NexmoResponseParseException, NexmoClientException {
         return this.message.execute(message);
     }
 
     /**
      * Search for completed SMS transactions.
      * <p>
-     * You should probably use the helper methods {@link #searchMessages(String, String...)} or
-     * {@link #searchMessages(String, String...)} instead.
+     * You should probably use the helper methods {@link #searchMessages(String, String...)} or {@link
+     * #searchMessages(String, String...)} instead.
+     * <p>
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public SearchSmsResponse searchMessages(SearchSmsRequest request) throws IOException, NexmoClientException {
+    public SearchSmsResponse searchMessages(SearchSmsRequest request) throws NexmoResponseParseException, NexmoClientException {
         return this.search.execute(request);
     }
 
@@ -94,9 +99,12 @@ public class SmsClient {
      * @param id  the first ID to look up
      * @param ids optional extra IDs to look up
      *
-     * @return SMS data matching the provided criteria
+     * @return SMS data matching the provided criteria.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public SearchSmsResponse searchMessages(String id, String... ids) throws IOException, NexmoClientException {
+    public SearchSmsResponse searchMessages(String id, String... ids) throws NexmoResponseParseException, NexmoClientException {
         List<String> idList = new ArrayList<>(ids.length + 1);
         idList.add(id);
         idList.addAll(Arrays.asList(ids));
@@ -110,8 +118,11 @@ public class SmsClient {
      * @param to   the MSISDN number of the SMS recipient
      *
      * @return SMS data matching the provided criteria
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public SearchSmsResponse searchMessages(Date date, String to) throws IOException, NexmoClientException {
+    public SearchSmsResponse searchMessages(Date date, String to) throws NexmoResponseParseException, NexmoClientException {
         return this.searchMessages(new SmsDateSearchRequest(date, to));
     }
 
@@ -121,8 +132,11 @@ public class SmsClient {
      * You should probably use {@link #searchRejectedMessages(Date, String)} instead.
      *
      * @return rejection data matching the provided criteria
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public SearchRejectedMessagesResponse searchRejectedMessages(SearchRejectedMessagesRequest request) throws IOException, NexmoClientException {
+    public SearchRejectedMessagesResponse searchRejectedMessages(SearchRejectedMessagesRequest request) throws NexmoResponseParseException, NexmoClientException {
         return this.rejected.execute(request);
     }
 
@@ -133,8 +147,11 @@ public class SmsClient {
      * @param to   the MSISDN number of the SMS recipient
      *
      * @return rejection data matching the provided criteria
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public SearchRejectedMessagesResponse searchRejectedMessages(Date date, String to) throws IOException, NexmoClientException {
+    public SearchRejectedMessagesResponse searchRejectedMessages(Date date, String to) throws NexmoResponseParseException, NexmoClientException {
         return this.searchRejectedMessages(new SearchRejectedMessagesRequest(date, to));
     }
 
@@ -145,10 +162,10 @@ public class SmsClient {
      *
      * @return SmsSingleSearchResponse object containing the details of the SMS.
      *
-     * @throws NexmoResponseParseException if the HTTP response could not be parsed.
-     * @throws IOException                 There has been an error attempting to communicate with the Nexmo service (e.g. Network failure).
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public SmsSingleSearchResponse getSms(String id) throws IOException, NexmoClientException {
+    public SmsSingleSearchResponse getSms(String id) throws NexmoResponseParseException, NexmoClientException {
         return this.singleSearch.execute(id);
     }
 }

--- a/src/main/java/com/nexmo/client/sms/SmsSearchEndpoint.java
+++ b/src/main/java/com/nexmo/client/sms/SmsSearchEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.sms;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -48,7 +47,7 @@ public class SmsSearchEndpoint extends AbstractMethod<SearchSmsRequest, SearchSm
     }
 
     @Override
-    public RequestBuilder makeRequest(SearchSmsRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(SearchSmsRequest request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;

--- a/src/main/java/com/nexmo/client/sms/SmsSingleSearchEndpoint.java
+++ b/src/main/java/com/nexmo/client/sms/SmsSingleSearchEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.sms;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -48,7 +47,7 @@ public class SmsSingleSearchEndpoint extends AbstractMethod<String, SmsSingleSea
     }
 
     @Override
-    public RequestBuilder makeRequest(String id) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(String id) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder.get(httpWrapper.getHttpConfig().getRestBaseUri() + PATH);
         requestBuilder.addParameter("id", id);
         return requestBuilder;

--- a/src/main/java/com/nexmo/client/sns/SnsClient.java
+++ b/src/main/java/com/nexmo/client/sns/SnsClient.java
@@ -25,16 +25,15 @@ package com.nexmo.client.sns;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClient;
 import com.nexmo.client.NexmoClientException;
+import com.nexmo.client.NexmoResponseParseException;
 import com.nexmo.client.sns.request.SnsPublishRequest;
 import com.nexmo.client.sns.request.SnsSubscribeRequest;
 import com.nexmo.client.sns.response.SnsPublishResponse;
 import com.nexmo.client.sns.response.SnsSubscribeResponse;
 
-import java.io.IOException;
-
 /**
- * A client for talking to the Nexmo Voice API. The standard way to obtain an instance of this class is to use
- * {@link NexmoClient#getSnsClient()}.
+ * A client for talking to the Nexmo Voice API. The standard way to obtain an instance of this class is to use {@link
+ * NexmoClient#getSnsClient()}.
  */
 public class SnsClient {
     private SnsEndpoint endpoint;
@@ -48,11 +47,11 @@ public class SnsClient {
         this.endpoint = new SnsEndpoint(httpWrapper);
     }
 
-    public SnsPublishResponse publish(SnsPublishRequest request) throws NexmoClientException, IOException {
+    public SnsPublishResponse publish(SnsPublishRequest request) throws NexmoClientException, NexmoResponseParseException {
         return (SnsPublishResponse) this.endpoint.execute(request);
     }
 
-    public SnsSubscribeResponse subscribe(SnsSubscribeRequest request) throws NexmoClientException, IOException {
+    public SnsSubscribeResponse subscribe(SnsSubscribeRequest request) throws NexmoClientException, NexmoResponseParseException {
         return (SnsSubscribeResponse) this.endpoint.execute(request);
     }
 }

--- a/src/main/java/com/nexmo/client/sns/SnsEndpoint.java
+++ b/src/main/java/com/nexmo/client/sns/SnsEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.sns;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.NexmoResponseParseException;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
@@ -65,7 +64,7 @@ class SnsEndpoint extends AbstractMethod<SnsRequest, SnsResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(SnsRequest snsRequest) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(SnsRequest snsRequest) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder
                 .post(httpWrapper.getHttpConfig().getSnsBaseUri() + PATH)
                 .addParameter("cmd", snsRequest.getCommand());

--- a/src/main/java/com/nexmo/client/verify/CheckMethod.java
+++ b/src/main/java/com/nexmo/client/verify/CheckMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.verify;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
@@ -48,7 +47,7 @@ class CheckMethod extends AbstractMethod<CheckRequest, CheckResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(CheckRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(CheckRequest request) throws UnsupportedEncodingException {
         if (request.getRequestId() == null || request.getCode() == null)
             throw new IllegalArgumentException("request ID and code parameters are mandatory.");
 

--- a/src/main/java/com/nexmo/client/verify/ControlEndpoint.java
+++ b/src/main/java/com/nexmo/client/verify/ControlEndpoint.java
@@ -49,7 +49,7 @@ class ControlEndpoint extends AbstractMethod<ControlRequest, ControlResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(ControlRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(ControlRequest request) throws UnsupportedEncodingException {
         RequestBuilder requestBuilder = RequestBuilder.post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH);
         request.addParams(requestBuilder);
         return requestBuilder;

--- a/src/main/java/com/nexmo/client/verify/SearchMethod.java
+++ b/src/main/java/com/nexmo/client/verify/SearchMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.verify;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
@@ -48,7 +47,7 @@ class SearchMethod extends AbstractMethod<SearchRequest, SearchVerifyResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(SearchRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(SearchRequest request) throws UnsupportedEncodingException {
         RequestBuilder result = RequestBuilder.post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH);
         if (request.getRequestIds().length == 1) {
             result.addParameter("request_id", request.getRequestIds()[0]);

--- a/src/main/java/com/nexmo/client/verify/VerifyClient.java
+++ b/src/main/java/com/nexmo/client/verify/VerifyClient.java
@@ -21,20 +21,17 @@
  */
 package com.nexmo.client.verify;
 
-import com.nexmo.client.AbstractClient;
-import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClient;
-import com.nexmo.client.NexmoClientException;
+import com.nexmo.client.*;
 
 import java.io.IOException;
 import java.util.Locale;
 
 /**
- * A client for talking to the Nexmo Verify API. The standard way to obtain an instance of this class is to use
- * {@link NexmoClient#getVerifyClient()}.
+ * A client for talking to the Nexmo Verify API. The standard way to obtain an instance of this class is to use {@link
+ * NexmoClient#getVerifyClient()}.
  * <p>
- * Send a verification request with a call to {@link #verify}, confirm the code entered by the user with
- * {@link #check}, and search in-progress or completed verification requests with {@link #search}
+ * Send a verification request with a call to {@link #verify}, confirm the code entered by the user with {@link #check},
+ * and search in-progress or completed verification requests with {@link #search}
  * <p>
  * More information on method parameters can be found at Nexmo website:
  * <a href="https://docs.nexmo.com/verify">https://docs.nexmo.com/verify</a>
@@ -67,11 +64,13 @@ public class VerifyClient extends AbstractClient {
      *               format.
      * @param brand  (required) The name of the company or app to be verified for. Must not be longer than 18
      *               characters.
+     *
      * @return a VerifyResponse representing the response received from the Verify API call.
-     * @throws IOException          if a network error occurred contacting the Nexmo Verify API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public VerifyResponse verify(final String number, final String brand) throws IOException, NexmoClientException {
+    public VerifyResponse verify(final String number, final String brand) throws NexmoResponseParseException, NexmoClientException {
         return this.verify.verify(number, brand);
     }
 
@@ -84,13 +83,15 @@ public class VerifyClient extends AbstractClient {
      *               characters.
      * @param from   (optional The Nexmo number to use as the sender for the verification SMS message and calls, in
      *               <a href="https://en.wikipedia.org/wiki/E.164">E.164</a> format.
+     *
      * @return a VerifyResponse representing the response received from the Verify API call.
-     * @throws IOException          if a network error occurred contacting the Nexmo Verify API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public VerifyResponse verify(final String number,
-                               final String brand,
-                               final String from) throws IOException, NexmoClientException {
+                                 final String brand,
+                                 final String from) throws IOException, NexmoClientException {
         return this.verify.verify(number, brand, from);
     }
 
@@ -107,15 +108,17 @@ public class VerifyClient extends AbstractClient {
      *               -1 to use the default value.
      * @param locale (optional) Override the default locale used for verification. By default the locale is determined
      *               from the country code included in {@code number}
+     *
      * @return a VerifyResponse representing the response received from the Verify API call.
-     * @throws IOException          if a network error occurred contacting the Nexmo Verify API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public VerifyResponse verify(final String number,
-                               final String brand,
-                               final String from,
-                               final int length,
-                               final Locale locale) throws IOException, NexmoClientException {
+                                 final String brand,
+                                 final String from,
+                                 final int length,
+                                 final Locale locale) throws IOException, NexmoClientException {
         return this.verify.verify(number, brand, from, length, locale);
     }
 
@@ -134,16 +137,18 @@ public class VerifyClient extends AbstractClient {
      *               from the country code included in {@code number}
      * @param type   (optional) If provided, restrict the verification to the specified network type. Contact
      *               support@nexmo.com to enable this feature.
+     *
      * @return a VerifyResponse representing the response received from the Verify API call.
-     * @throws IOException          if a network error occurred contacting the Nexmo Verify API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public VerifyResponse verify(final String number,
-                               final String brand,
-                               final String from,
-                               final int length,
-                               final Locale locale,
-                               final VerifyRequest.LineType type) throws IOException, NexmoClientException {
+                                 final String brand,
+                                 final String from,
+                                 final int length,
+                                 final Locale locale,
+                                 final VerifyRequest.LineType type) throws IOException, NexmoClientException {
         return this.verify.verify(number, brand, from, length, locale, type);
     }
 
@@ -159,9 +164,11 @@ public class VerifyClient extends AbstractClient {
      *
      * @param requestId (required) The requestId returned by the {@code verify} call.
      * @param code      (required) The code entered by the user.
+     *
      * @return a CheckResponse representing the response received from the API call.
-     * @throws IOException          if a network error occurred contacting the Nexmo Verify API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public CheckResponse check(final String requestId, final String code) throws IOException, NexmoClientException {
         return this.check.check(requestId, code);
@@ -173,13 +180,15 @@ public class VerifyClient extends AbstractClient {
      * @param requestId (required) The requestId returned by the {@code verify} call.
      * @param code      (required) The code entered by the user.
      * @param ipAddress (optional) The IP address obtained from the HTTP request made when the user entered their code.
+     *
      * @return a CheckResponse representing the response received from the API call.
-     * @throws IOException          if a network error occurred contacting the Nexmo Verify API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public CheckResponse check(final String requestId,
-                             final String code,
-                             final String ipAddress) throws IOException, NexmoClientException {
+                               final String code,
+                               final String ipAddress) throws IOException, NexmoClientException {
         return this.check.check(requestId, code, ipAddress);
     }
 
@@ -187,10 +196,12 @@ public class VerifyClient extends AbstractClient {
      * Search for a previous verification request.
      *
      * @param requestId The requestId of a single Verify request to be looked up.
-     * @return A SearchVerifyResponse containing the details of the Verify request that was looked up, or {@code null} if no
-     * record was found.
-     * @throws IOException          if a network error occurred contacting the Nexmo Verify API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     *
+     * @return A SearchVerifyResponse containing the details of the Verify request that was looked up, or {@code null}
+     * if no record was found.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public SearchVerifyResponse search(String requestId) throws IOException, NexmoClientException {
         return this.search.search(requestId);
@@ -200,9 +211,11 @@ public class VerifyClient extends AbstractClient {
      * Search for a previous verification request.
      *
      * @param requestIds The requestIds of Verify requests to be looked up.
+     *
      * @return An array SearchVerifyResponse for each record that was found.
-     * @throws IOException          if a network error occurred contacting the Nexmo Verify API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public SearchVerifyResponse search(String... requestIds) throws IOException, NexmoClientException {
         return this.search.search(requestIds);
@@ -212,9 +225,11 @@ public class VerifyClient extends AbstractClient {
      * Advance a current verification request to the next stage in the process.
      *
      * @param requestId The requestId of the ongoing verification request.
+     *
      * @return A {@link ControlResponse} representing the response from the API.
-     * @throws IOException          If an IO error occurred while making the request.
-     * @throws NexmoClientException If the request failed for some reason.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public ControlResponse advanceVerification(String requestId) throws IOException, NexmoClientException {
         return this.control.execute(new ControlRequest(requestId, VerifyControlCommand.TRIGGER_NEXT_EVENT));
@@ -224,9 +239,11 @@ public class VerifyClient extends AbstractClient {
      * Cancel a current verification request.
      *
      * @param requestId The requestId of the ongoing verification request.
+     *
      * @return A {@link ControlResponse} representing the response from the API.
-     * @throws IOException          If an IO error occurred while making the request.
-     * @throws NexmoClientException If the request failed for some reason.
+     *
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
     public ControlResponse cancelVerification(String requestId) throws IOException, NexmoClientException {
         return this.control.execute(new ControlRequest(requestId, VerifyControlCommand.CANCEL));

--- a/src/main/java/com/nexmo/client/verify/VerifyEndpoint.java
+++ b/src/main/java/com/nexmo/client/verify/VerifyEndpoint.java
@@ -24,7 +24,6 @@ package com.nexmo.client.verify;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClientException;
 
-import java.io.IOException;
 import java.util.Locale;
 
 class VerifyEndpoint {
@@ -34,23 +33,23 @@ class VerifyEndpoint {
         this.verifyMethod = new VerifyMethod(httpWrapper);
     }
 
-    VerifyResponse verify(String number, String brand, String from, int length, Locale locale, VerifyRequest.LineType type) throws IOException, NexmoClientException {
+    VerifyResponse verify(String number, String brand, String from, int length, Locale locale, VerifyRequest.LineType type) throws NexmoClientException {
         return verify(new VerifyRequest(number, brand, from, length, locale, type));
     }
 
-    VerifyResponse verify(String number, String brand, String from, int length, Locale locale) throws IOException, NexmoClientException {
+    VerifyResponse verify(String number, String brand, String from, int length, Locale locale) throws NexmoClientException {
         return verify(new VerifyRequest(number, brand, from, length, locale));
     }
 
-    VerifyResponse verify(String number, String brand, String from) throws IOException, NexmoClientException {
+    VerifyResponse verify(String number, String brand, String from) throws NexmoClientException {
         return verify(new VerifyRequest(number, brand, from));
     }
 
-    VerifyResponse verify(String number, String brand) throws IOException, NexmoClientException {
+    VerifyResponse verify(String number, String brand) throws NexmoClientException {
         return verify(new VerifyRequest(number, brand));
     }
 
-    VerifyResponse verify(VerifyRequest request) throws IOException, NexmoClientException {
+    VerifyResponse verify(VerifyRequest request) throws NexmoClientException {
         return this.verifyMethod.execute(request);
     }
 }

--- a/src/main/java/com/nexmo/client/verify/VerifyMethod.java
+++ b/src/main/java/com/nexmo/client/verify/VerifyMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.verify;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.SignatureAuthMethod;
 import com.nexmo.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
@@ -49,7 +48,7 @@ class VerifyMethod extends AbstractMethod<VerifyRequest, VerifyResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(VerifyRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(VerifyRequest request) throws UnsupportedEncodingException {
         RequestBuilder result = RequestBuilder
                 .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
                 .addParameter("number", request.getNumber())

--- a/src/main/java/com/nexmo/client/voice/CallsEndpoint.java
+++ b/src/main/java/com/nexmo/client/voice/CallsEndpoint.java
@@ -24,8 +24,6 @@ package com.nexmo.client.voice;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClientException;
 
-import java.io.IOException;
-
 /**
  * Allows actions to be taken on {@code /calls/*} endpoints.
  * <p>
@@ -58,7 +56,6 @@ class CallsEndpoint {
      *
      * @return A CallEvent describing the call that was initiated.
      *
-     * @throws IOException          if an error occurs communicating with the Nexmo API
      * @throws NexmoClientException if an error occurs constructing the Nexmo API request or response
      */
     CallEvent post(Call callRequest) throws NexmoClientException {
@@ -72,7 +69,6 @@ class CallsEndpoint {
      *
      * @return A CallInfoPage containing a single page of {@link CallInfo} results
      *
-     * @throws IOException          if an error occurs communicating with the Nexmo API
      * @throws NexmoClientException if an error occurs constructing the Nexmo API request or response
      */
     CallInfoPage get(CallsFilter filter) throws NexmoClientException {
@@ -86,7 +82,6 @@ class CallsEndpoint {
      *
      * @return A CallInfo object describing the state of the call that was made or is in progress
      *
-     * @throws IOException          if an error occurs communicating with the Nexmo API
      * @throws NexmoClientException if an error occurs constructing the Nexmo API request or response
      */
     CallInfo get(String uuid) throws NexmoClientException {
@@ -100,7 +95,6 @@ class CallsEndpoint {
      *
      * @return A ModifyCallResponse object describing the state of the call that was modified
      *
-     * @throws IOException          if an error occurs communicating with the Nexmo API
      * @throws NexmoClientException if an error occurs constructing the Nexmo API request or response
      */
     ModifyCallResponse put(CallModifier modifier) throws NexmoClientException {

--- a/src/main/java/com/nexmo/client/voice/CallsEndpoint.java
+++ b/src/main/java/com/nexmo/client/voice/CallsEndpoint.java
@@ -61,7 +61,7 @@ class CallsEndpoint {
      * @throws IOException          if an error occurs communicating with the Nexmo API
      * @throws NexmoClientException if an error occurs constructing the Nexmo API request or response
      */
-    CallEvent post(Call callRequest) throws IOException, NexmoClientException {
+    CallEvent post(Call callRequest) throws NexmoClientException {
         return this.createCall.execute(callRequest);
     }
 
@@ -75,7 +75,7 @@ class CallsEndpoint {
      * @throws IOException          if an error occurs communicating with the Nexmo API
      * @throws NexmoClientException if an error occurs constructing the Nexmo API request or response
      */
-    CallInfoPage get(CallsFilter filter) throws IOException, NexmoClientException {
+    CallInfoPage get(CallsFilter filter) throws NexmoClientException {
         return this.listCalls.execute(filter);
     }
 
@@ -89,7 +89,7 @@ class CallsEndpoint {
      * @throws IOException          if an error occurs communicating with the Nexmo API
      * @throws NexmoClientException if an error occurs constructing the Nexmo API request or response
      */
-    CallInfo get(String uuid) throws IOException, NexmoClientException {
+    CallInfo get(String uuid) throws NexmoClientException {
         return this.readCall.execute(uuid);
     }
 
@@ -103,7 +103,7 @@ class CallsEndpoint {
      * @throws IOException          if an error occurs communicating with the Nexmo API
      * @throws NexmoClientException if an error occurs constructing the Nexmo API request or response
      */
-    ModifyCallResponse put(CallModifier modifier) throws IOException, NexmoClientException {
+    ModifyCallResponse put(CallModifier modifier) throws NexmoClientException {
         return this.modifyCall.execute(modifier);
     }
 }

--- a/src/main/java/com/nexmo/client/voice/CreateCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/CreateCallMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.voice;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -48,7 +47,7 @@ class CreateCallMethod extends AbstractMethod<Call, CallEvent> {
     }
 
     @Override
-    public RequestBuilder makeRequest(Call request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(Call request) throws UnsupportedEncodingException {
         return RequestBuilder.post(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH)
                 .setHeader("Content-Type", "application/json")
                 .setEntity(new StringEntity(request.toJson(), ContentType.APPLICATION_JSON));

--- a/src/main/java/com/nexmo/client/voice/DownloadRecordingEndpoint.java
+++ b/src/main/java/com/nexmo/client/voice/DownloadRecordingEndpoint.java
@@ -23,7 +23,6 @@ package com.nexmo.client.voice;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -43,7 +42,7 @@ class DownloadRecordingEndpoint extends AbstractMethod<String, Recording> {
     }
 
     @Override
-    public RequestBuilder makeRequest(String uri) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(String uri) throws UnsupportedEncodingException {
         return RequestBuilder.get().setUri(uri);
     }
 

--- a/src/main/java/com/nexmo/client/voice/DtmfEndpoint.java
+++ b/src/main/java/com/nexmo/client/voice/DtmfEndpoint.java
@@ -24,8 +24,6 @@ package com.nexmo.client.voice;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClientException;
 
-import java.io.IOException;
-
 public class DtmfEndpoint {
     private final SendDtmfMethod sendDtmf;
 
@@ -33,7 +31,7 @@ public class DtmfEndpoint {
         this.sendDtmf = new SendDtmfMethod(httpWrapper);
     }
 
-    public DtmfResponse put(String uuid, String digits) throws IOException, NexmoClientException {
+    public DtmfResponse put(String uuid, String digits) throws NexmoClientException {
         return this.sendDtmf.execute(new DtmfRequest(uuid, digits));
     }
 }

--- a/src/main/java/com/nexmo/client/voice/ListCallsMethod.java
+++ b/src/main/java/com/nexmo/client/voice/ListCallsMethod.java
@@ -24,7 +24,6 @@ package com.nexmo.client.voice;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.NexmoUnexpectedException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.commons.logging.Log;
@@ -57,7 +56,7 @@ class ListCallsMethod extends AbstractMethod<CallsFilter, CallInfoPage> {
     }
 
     @Override
-    public RequestBuilder makeRequest(CallsFilter filter) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(CallsFilter filter) throws UnsupportedEncodingException {
         URIBuilder uriBuilder;
         String uri = httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH;
 

--- a/src/main/java/com/nexmo/client/voice/ModifyCallMethod.java
+++ b/src/main/java/com/nexmo/client/voice/ModifyCallMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.voice;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -53,7 +52,7 @@ class ModifyCallMethod extends AbstractMethod<CallModifier, ModifyCallResponse> 
     }
 
     @Override
-    public RequestBuilder makeRequest(CallModifier request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(CallModifier request) throws UnsupportedEncodingException {
         String uri = this.uri + request.getUuid();
         return RequestBuilder
                 .put(uri)

--- a/src/main/java/com/nexmo/client/voice/SendDtmfMethod.java
+++ b/src/main/java/com/nexmo/client/voice/SendDtmfMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.voice;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -53,7 +52,7 @@ class SendDtmfMethod extends AbstractMethod<DtmfRequest, DtmfResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(DtmfRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(DtmfRequest request) throws UnsupportedEncodingException {
         String uri = this.uri + request.getUuid() + "/dtmf";
         return RequestBuilder.put(uri)
                 .setHeader("Content-Type", "application/json")

--- a/src/main/java/com/nexmo/client/voice/StartStreamMethod.java
+++ b/src/main/java/com/nexmo/client/voice/StartStreamMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.voice;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -53,7 +52,7 @@ class StartStreamMethod extends AbstractMethod<StreamRequest, StreamResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(StreamRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(StreamRequest request) throws UnsupportedEncodingException {
         return RequestBuilder
                 .put(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + request.getUuid() + "/stream")
                 .setHeader("Content-Type", "application/json")

--- a/src/main/java/com/nexmo/client/voice/StartTalkMethod.java
+++ b/src/main/java/com/nexmo/client/voice/StartTalkMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.voice;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -53,7 +52,7 @@ class StartTalkMethod extends AbstractMethod<TalkRequest, TalkResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(TalkRequest request) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(TalkRequest request) throws UnsupportedEncodingException {
         return RequestBuilder
                 .put(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + request.getUuid() + "/talk")
                 .setHeader("Content-Type", "application/json")

--- a/src/main/java/com/nexmo/client/voice/StopStreamMethod.java
+++ b/src/main/java/com/nexmo/client/voice/StopStreamMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.voice;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -51,7 +50,7 @@ class StopStreamMethod extends AbstractMethod<String, StreamResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(String uuid) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(String uuid) throws UnsupportedEncodingException {
         return RequestBuilder
                 .delete(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v1") + PATH + uuid + "/stream")
                 .setHeader("Content-Type", "application/json");

--- a/src/main/java/com/nexmo/client/voice/StopTalkMethod.java
+++ b/src/main/java/com/nexmo/client/voice/StopTalkMethod.java
@@ -23,7 +23,6 @@ package com.nexmo.client.voice;
 
 import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.JWTAuthMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -51,7 +50,7 @@ class StopTalkMethod extends AbstractMethod<String, TalkResponse> {
     }
 
     @Override
-    public RequestBuilder makeRequest(String uuid) throws NexmoClientException, UnsupportedEncodingException {
+    public RequestBuilder makeRequest(String uuid) throws UnsupportedEncodingException {
         String uri = this.uri + uuid + "/talk";
         return RequestBuilder.delete(uri).setHeader("Content-Type", "application/json");
     }

--- a/src/main/java/com/nexmo/client/voice/StreamsEndpoint.java
+++ b/src/main/java/com/nexmo/client/voice/StreamsEndpoint.java
@@ -24,8 +24,6 @@ package com.nexmo.client.voice;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClientException;
 
-import java.io.IOException;
-
 class StreamsEndpoint {
     private final StartStreamMethod startStream;
     private final StopStreamMethod stopStream;
@@ -35,11 +33,11 @@ class StreamsEndpoint {
         this.stopStream = new StopStreamMethod(wrapper);
     }
 
-    public StreamResponse put(StreamRequest request) throws IOException, NexmoClientException {
+    public StreamResponse put(StreamRequest request) throws NexmoClientException {
         return this.startStream.execute(request);
     }
 
-    public StreamResponse delete(String uuid) throws IOException, NexmoClientException {
+    public StreamResponse delete(String uuid) throws NexmoClientException {
         return this.stopStream.execute(uuid);
     }
 }

--- a/src/main/java/com/nexmo/client/voice/TalkEndpoint.java
+++ b/src/main/java/com/nexmo/client/voice/TalkEndpoint.java
@@ -24,8 +24,6 @@ package com.nexmo.client.voice;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoClientException;
 
-import java.io.IOException;
-
 public class TalkEndpoint {
     private final StartTalkMethod startTalk;
     private final StopTalkMethod stopTalk;
@@ -35,11 +33,11 @@ public class TalkEndpoint {
         this.stopTalk = new StopTalkMethod(wrapper);
     }
 
-    public TalkResponse put(TalkRequest request) throws IOException, NexmoClientException {
+    public TalkResponse put(TalkRequest request) throws NexmoClientException {
         return this.startTalk.execute(request);
     }
 
-    public TalkResponse delete(String uuid) throws IOException, NexmoClientException {
+    public TalkResponse delete(String uuid) throws NexmoClientException {
         return this.stopTalk.execute(uuid);
     }
 }

--- a/src/main/java/com/nexmo/client/voice/VoiceClient.java
+++ b/src/main/java/com/nexmo/client/voice/VoiceClient.java
@@ -22,16 +22,11 @@
 package com.nexmo.client.voice;
 
 
-import com.nexmo.client.AbstractClient;
-import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoClient;
-import com.nexmo.client.NexmoClientException;
-
-import java.io.IOException;
+import com.nexmo.client.*;
 
 /**
- * A client for talking to the Nexmo Voice API. The standard way to obtain an instance of this class is to use
- * {@link NexmoClient#getVoiceClient()}.
+ * A client for talking to the Nexmo Voice API. The standard way to obtain an instance of this class is to use {@link
+ * NexmoClient#getVoiceClient()}.
  */
 public class VoiceClient extends AbstractClient {
     protected final CallsEndpoint calls;
@@ -60,26 +55,26 @@ public class VoiceClient extends AbstractClient {
      *
      * @param callRequest Describing the call to be made.
      *
-     * @return A CallEvent describing the initial state of the call, containing the {@code uuid} required to
-     *         interact with the ongoing phone call.
+     * @return A CallEvent describing the initial state of the call, containing the {@code uuid} required to interact
+     * with the ongoing phone call.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public CallEvent createCall(Call callRequest) throws IOException, NexmoClientException {
+    public CallEvent createCall(Call callRequest) throws NexmoResponseParseException, NexmoClientException {
         return calls.post(callRequest);
     }
 
     /**
-     * Obtain the first page of CallInfo objects, representing the most recent calls initiated by
-     * {@link #createCall(Call)}.
+     * Obtain the first page of CallInfo objects, representing the most recent calls initiated by {@link
+     * #createCall(Call)}.
      *
      * @return A CallInfoPage representing the response from the Nexmo Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public CallInfoPage listCalls() throws IOException, NexmoClientException {
+    public CallInfoPage listCalls() throws NexmoResponseParseException, NexmoClientException {
         return this.listCalls(null);
     }
 
@@ -91,25 +86,25 @@ public class VoiceClient extends AbstractClient {
      *
      * @return A CallInfoPage representing the response from the Nexmo Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public CallInfoPage listCalls(CallsFilter filter) throws IOException, NexmoClientException {
+    public CallInfoPage listCalls(CallsFilter filter) throws NexmoResponseParseException, NexmoClientException {
         return calls.get(filter);
     }
 
     /**
      * Look up the status of a single call initiated by {@link #createCall(Call)}.
      *
-     * @param uuid (required) The UUID of the call, obtained from the object returned by {@link #createCall(Call)}.
-     *             This value can be obtained with {@link CallEvent#getUuid()}
+     * @param uuid (required) The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This
+     *             value can be obtained with {@link CallEvent#getUuid()}
      *
      * @return A CallInfo object, representing the response from the Nexmo Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public CallInfo getCallDetails(String uuid) throws IOException, NexmoClientException {
+    public CallInfo getCallDetails(String uuid) throws NexmoResponseParseException, NexmoClientException {
         return calls.get(uuid);
     }
 
@@ -119,15 +114,15 @@ public class VoiceClient extends AbstractClient {
      * @param uuid   (required) The UUID of the call, obtained from the object returned by {@link #createCall(Call)}.
      *               This value can be obtained with {@link CallEvent#getUuid()}
      * @param digits (required) A string specifying the digits to be sent to the call. Valid characters are the digits
-     *               {@code 1-9</tt>, <tt>#</tt>, <tt>*</tt>, with the special character <tt>p} indicating a short
-     *               pause between tones.
+     *               {@code 1-9</tt>, <tt>#</tt>, <tt>*</tt>, with the special character <tt>p} indicating a short pause
+     *               between tones.
      *
      * @return A CallInfo object, representing the response from the Nexmo Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public DtmfResponse sendDtmf(String uuid, String digits) throws IOException, NexmoClientException {
+    public DtmfResponse sendDtmf(String uuid, String digits) throws NexmoResponseParseException, NexmoClientException {
         return dtmf.put(uuid, digits);
     }
 
@@ -143,83 +138,83 @@ public class VoiceClient extends AbstractClient {
      * <li>Unearmuff a call leg (unearmuff)
      * </ul>
      *
-     * @param uuid   The UUID of the call, obtained from the object returned by {@link #createCall(Call)}.
-     *               This value can be obtained with {@link CallEvent#getUuid()}
+     * @param uuid   The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value
+     *               can be obtained with {@link CallEvent#getUuid()}
      * @param action One of: "hangup", "mute", "unmute", "earmuff", "unearmuff"
      *
      * @return A ModifyCallResponse object, representing the response from the Nexmo Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public ModifyCallResponse modifyCall(String uuid, ModifyCallAction action) throws IOException, NexmoClientException {
+    public ModifyCallResponse modifyCall(String uuid, ModifyCallAction action) throws NexmoResponseParseException, NexmoClientException {
         return this.modifyCall(new CallModifier(uuid, action));
     }
 
     /**
      * Modify an ongoing call using a CallModifier object.
      * <p>
-     * In most cases, you will want to use {@link #modifyCall(String, ModifyCallAction)} or {@link #transferCall(String, String)}
-     * instead of this method.
+     * In most cases, you will want to use {@link #modifyCall(String, ModifyCallAction)} or {@link #transferCall(String,
+     * String)} instead of this method.
      *
      * @param modifier A CallModifier describing the modification to be made.
      *
      * @return A ModifyCallResponse object, representing the response from the Nexmo Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public ModifyCallResponse modifyCall(CallModifier modifier) throws IOException, NexmoClientException {
+    public ModifyCallResponse modifyCall(CallModifier modifier) throws NexmoResponseParseException, NexmoClientException {
         return calls.put(modifier);
     }
 
     /**
      * Transfer a call to a different NCCO endpoint.
      *
-     * @param uuid    The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value can
-     *                be obtained with {@link CallEvent#getUuid()}
+     * @param uuid    The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value
+     *                can be obtained with {@link CallEvent#getUuid()}
      * @param nccoUrl The URL of the NCCO endpoint the call should be transferred to
      *
      * @return A ModifyCallResponse object, representing the response from the Nexmo Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public ModifyCallResponse transferCall(String uuid, String nccoUrl) throws IOException, NexmoClientException {
+    public ModifyCallResponse transferCall(String uuid, String nccoUrl) throws NexmoResponseParseException, NexmoClientException {
         return this.modifyCall(CallModifier.transferCall(uuid, nccoUrl));
     }
 
     /**
      * Stream audio to an ongoing call.
      *
-     * @param uuid      The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value can
-     *                  be obtained with {@link CallEvent#getUuid()}
+     * @param uuid      The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value
+     *                  can be obtained with {@link CallEvent#getUuid()}
      * @param streamUrl A URL of an audio file in MP3 or 16-bit WAV format, to be streamed to the call.
-     * @param loop      The number of times to repeat the audio. The default value is {@code 1}, or you can use
-     *                  {@code 0} to indicate that the audio should be repeated indefinitely.
+     * @param loop      The number of times to repeat the audio. The default value is {@code 1}, or you can use {@code
+     *                  0} to indicate that the audio should be repeated indefinitely.
      *
      * @return The data returned from the Voice API
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public StreamResponse startStream(String uuid, String streamUrl, int loop) throws IOException, NexmoClientException {
+    public StreamResponse startStream(String uuid, String streamUrl, int loop) throws NexmoResponseParseException, NexmoClientException {
         return streams.put(new StreamRequest(uuid, streamUrl, loop));
     }
 
     /**
      * Stream audio to an ongoing call.
      *
-     * @param uuid      The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value can
-     *                  be obtained with {@link CallEvent#getUuid()}
+     * @param uuid      The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value
+     *                  can be obtained with {@link CallEvent#getUuid()}
      * @param streamUrl A URL of an audio file in MP3 or 16-bit WAV format, to be streamed to the call.
      *
      * @return The data returned from the Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public StreamResponse startStream(String uuid, String streamUrl) throws IOException, NexmoClientException {
+    public StreamResponse startStream(String uuid, String streamUrl) throws NexmoResponseParseException, NexmoClientException {
         return streams.put(new StreamRequest(uuid, streamUrl, 1));
     }
 
@@ -231,10 +226,10 @@ public class VoiceClient extends AbstractClient {
      *
      * @return The data returned from the Voice API
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public StreamResponse stopStream(String uuid) throws IOException, NexmoClientException {
+    public StreamResponse stopStream(String uuid) throws NexmoResponseParseException, NexmoClientException {
         return streams.delete(uuid);
     }
 
@@ -249,27 +244,27 @@ public class VoiceClient extends AbstractClient {
      *
      * @return The data returned from the Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public TalkResponse startTalk(String uuid, String text) throws IOException, NexmoClientException {
+    public TalkResponse startTalk(String uuid, String text) throws NexmoResponseParseException, NexmoClientException {
         return talk.put(new TalkRequest(uuid, text));
     }
 
     /**
      * Send a synthesized speech message to an ongoing call.
      *
-     * @param uuid      The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value can
-     *                  be obtained with {@link CallEvent#getUuid()}
+     * @param uuid      The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value
+     *                  can be obtained with {@link CallEvent#getUuid()}
      * @param text      The message to be spoken to the call participants.
      * @param voiceName The voice to be used to speak the message.
      *
      * @return The data returned from the Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public TalkResponse startTalk(String uuid, String text, VoiceName voiceName) throws IOException, NexmoClientException {
+    public TalkResponse startTalk(String uuid, String text, VoiceName voiceName) throws NexmoResponseParseException, NexmoClientException {
         return talk.put(new TalkRequest(uuid, text, voiceName));
     }
 
@@ -281,34 +276,34 @@ public class VoiceClient extends AbstractClient {
      * @param uuid The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value can
      *             be obtained with {@link CallEvent#getUuid()}
      * @param text The message to be spoken to the call participants.
-     * @param loop The number of times to repeat the message. The default value is {@code 1}, or you can use
-     *             {@code 0} to indicate that the message should be repeated indefinitely.
+     * @param loop The number of times to repeat the message. The default value is {@code 1}, or you can use {@code 0}
+     *             to indicate that the message should be repeated indefinitely.
      *
      * @return The data returned from the Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public TalkResponse startTalk(String uuid, String text, int loop) throws IOException, NexmoClientException {
+    public TalkResponse startTalk(String uuid, String text, int loop) throws NexmoResponseParseException, NexmoClientException {
         return talk.put(new TalkRequest(uuid, text, loop));
     }
 
     /**
      * Send a synthesized speech message to an ongoing call.
      *
-     * @param uuid      The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value can
-     *                  be obtained with {@link CallEvent#getUuid()}
+     * @param uuid      The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This value
+     *                  can be obtained with {@link CallEvent#getUuid()}
      * @param text      The message to be spoken to the call participants.
      * @param voiceName The voice to be used to speak the message.
-     * @param loop      The number of times to repeat the message. The default value is {@code 1}, or you can use
-     *                  {@code 0} to indicate that the message should be repeated indefinitely.
+     * @param loop      The number of times to repeat the message. The default value is {@code 1}, or you can use {@code
+     *                  0} to indicate that the message should be repeated indefinitely.
      *
      * @return The data returned from the Voice API.
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public TalkResponse startTalk(String uuid, String text, VoiceName voiceName, int loop) throws IOException, NexmoClientException {
+    public TalkResponse startTalk(String uuid, String text, VoiceName voiceName, int loop) throws NexmoResponseParseException, NexmoClientException {
         return talk.put(new TalkRequest(uuid, text, voiceName, loop));
     }
 
@@ -320,26 +315,27 @@ public class VoiceClient extends AbstractClient {
      *
      * @return The data returned from the Voice API
      *
-     * @throws IOException          if a network error occurred contacting the Nexmo Voice API.
-     * @throws NexmoClientException if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public TalkResponse stopTalk(String uuid) throws IOException, NexmoClientException {
+    public TalkResponse stopTalk(String uuid) throws NexmoResponseParseException, NexmoClientException {
         return talk.delete(uuid);
     }
 
     /**
      * Download a recording, given the recordingUrl provided from the webhook callback.
      * <p>
-     * This returns a {@link Recording} object which can provide an InputStream of the byte data, or can be used to
-     * save directly to file.
+     * This returns a {@link Recording} object which can provide an InputStream of the byte data, or can be used to save
+     * directly to file.
      *
      * @param recordingUrl The recordingUrl provided by the webhook callback
      *
      * @return A Recording object, providing access to the recording's bytes
      *
-     * @throws IOException If an error occurred while downloading the data
+     * @throws NexmoClientException        if there was a problem with the Nexmo request or response objects.
+     * @throws NexmoResponseParseException if the response from the API could not be parsed.
      */
-    public Recording downloadRecording(String recordingUrl) throws IOException, NexmoClientException {
+    public Recording downloadRecording(String recordingUrl) throws NexmoResponseParseException, NexmoClientException {
         return this.downloadRecording.execute(recordingUrl);
     }
 }

--- a/src/test/java/com/nexmo/client/AbstractMethodTest.java
+++ b/src/test/java/com/nexmo/client/AbstractMethodTest.java
@@ -42,8 +42,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.Set;
 
@@ -63,12 +61,12 @@ public class AbstractMethodTest {
         }
 
         @Override
-        public RequestBuilder makeRequest(String request) throws NexmoClientException, UnsupportedEncodingException {
+        public RequestBuilder makeRequest(String request) {
             return RequestBuilder.get(request);
         }
 
         @Override
-        public String parseResponse(HttpResponse response) throws IOException {
+        public String parseResponse(HttpResponse response) {
             return "response";
         }
     }
@@ -97,7 +95,7 @@ public class AbstractMethodTest {
 
     @Ignore
     @Test
-    public void testExecute() throws Exception {
+    public void testExecute() {
         ConcreteMethod method = new ConcreteMethod(mockWrapper);
 
         String result = method.execute("url");
@@ -105,7 +103,7 @@ public class AbstractMethodTest {
     }
 
     @Test
-    public void testGetAuthMethod() throws Exception {
+    public void testGetAuthMethod() {
         ConcreteMethod method = new ConcreteMethod(mockWrapper);
 
         AuthMethod auth = method.getAuthMethod(method.getAcceptableAuthMethods());
@@ -113,7 +111,7 @@ public class AbstractMethodTest {
     }
 
     @Test
-    public void testApplyAuth() throws Exception {
+    public void testApplyAuth() {
         ConcreteMethod method = new ConcreteMethod(mockWrapper);
 
         RequestBuilder request = RequestBuilder.get("url");

--- a/src/test/java/com/nexmo/client/NexmoClientTest.java
+++ b/src/test/java/com/nexmo/client/NexmoClientTest.java
@@ -254,6 +254,11 @@ public class NexmoClientTest {
         assertEquals(config, nexmoClient.getHttpWrapper().getHttpConfig());
     }
 
+    @Test(expected = NexmoUnableToReadPrivateKeyException.class)
+    public void testIOExceptionIsWrappedWithUnableToReadPrivateKeyException() {
+        NexmoClient.builder().privateKeyPath("this/path/does/not/exist");
+    }
+
     private void assertContainsParam(List<NameValuePair> params, String key, String value) {
         NameValuePair item = new BasicNameValuePair(key, value);
         assertTrue("" + params + " should contain " + item, params.contains(item));

--- a/src/test/java/com/nexmo/client/account/BalanceEndpointTest.java
+++ b/src/test/java/com/nexmo/client/account/BalanceEndpointTest.java
@@ -31,11 +31,9 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class BalanceEndpointTest {
     private BalanceEndpoint endpoint;
@@ -46,7 +44,7 @@ public class BalanceEndpointTest {
     }
 
     @Test
-    public void testGetAcceptableAuthMethods() throws Exception {
+    public void testGetAcceptableAuthMethods() {
         Class[] auths = this.endpoint.getAcceptableAuthMethods();
         assertArrayEquals(new Class[]{TokenAuthMethod.class}, auths);
     }
@@ -80,7 +78,7 @@ public class BalanceEndpointTest {
                 "}}");
         BalanceResponse response = this.endpoint.parseResponse(stub);
         assertEquals(3.14159, response.getValue(), 0.00001);
-        assertEquals(false, response.isAutoReload());
+        assertFalse(response.isAutoReload());
     }
 
     private class StubbedBalanceEndpoint extends BalanceEndpoint {
@@ -89,16 +87,16 @@ public class BalanceEndpointTest {
         }
 
         @Override
-        public BalanceResponse execute() throws IOException, NexmoClientException {
+        public BalanceResponse execute() throws NexmoClientException {
             return new BalanceResponse(1.5, true);
         }
     }
 
     @Test
-    public void testExecute() throws Exception {
+    public void testExecute() {
         BalanceEndpoint endpoint = new StubbedBalanceEndpoint();
         BalanceResponse response = endpoint.execute();
         assertEquals(response.getValue(), 1.5, 0.0001);
-        assertEquals(response.isAutoReload(), true);
+        assertTrue(response.isAutoReload());
     }
 }

--- a/src/test/java/com/nexmo/client/sms/SmsClientTest.java
+++ b/src/test/java/com/nexmo/client/sms/SmsClientTest.java
@@ -23,6 +23,7 @@ package com.nexmo.client.sms;
 
 
 import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoResponseParseException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import com.nexmo.client.sms.messages.Message;
 import com.nexmo.client.sms.messages.TextMessage;
@@ -37,15 +38,13 @@ import org.junit.Test;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class SmsClientTest {
     private HttpWrapper wrapper;
@@ -65,7 +64,7 @@ public class SmsClientTest {
         HttpEntity entity = mock(HttpEntity.class);
 
         when(result.execute(any(HttpUriRequest.class))).thenReturn(response);
-        when(entity.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes("UTF-8")));
+        when(entity.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
         when(sl.getStatusCode()).thenReturn(statusCode);
         when(response.getStatusLine()).thenReturn(sl);
         when(response.getEntity()).thenReturn(entity);
@@ -113,8 +112,8 @@ public class SmsClientTest {
         Message message = new TextMessage("TestSender", "not-a-number", "Test");
         try {
             client.submitMessage(message);
-            fail("An IOException should be thrown if an HTTP 500 response is received.");
-        } catch (IOException ioe) {
+            fail("A NexmoResponseParseException should be thrown if an HTTP 500 response is received.");
+        } catch (NexmoResponseParseException nrp) {
             // This is expected
         }
     }
@@ -253,7 +252,7 @@ public class SmsClientTest {
         assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2011-11-25 16:03:00"), response.getDateReceived());
         assertEquals("DELIVRD", response.getFinalStatus());
         assertEquals(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2011-11-25 16:03:00"), response.getDateClosed());
-        assertEquals(new Integer(11151), response.getLatency());
+        assertEquals(Integer.valueOf(11151), response.getLatency());
         assertEquals("MT", response.getType());
     }
 }

--- a/src/test/java/com/nexmo/client/sns/SnsClientTest.java
+++ b/src/test/java/com/nexmo/client/sns/SnsClientTest.java
@@ -23,6 +23,7 @@ package com.nexmo.client.sns;
 
 
 import com.nexmo.client.HttpWrapper;
+import com.nexmo.client.NexmoResponseParseException;
 import com.nexmo.client.auth.TokenAuthMethod;
 import com.nexmo.client.sns.request.SnsPublishRequest;
 import com.nexmo.client.sns.request.SnsSubscribeRequest;
@@ -37,7 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -61,7 +62,7 @@ public class SnsClientTest {
         HttpEntity entity = mock(HttpEntity.class);
 
         when(result.execute(any(HttpUriRequest.class))).thenReturn(response);
-        when(entity.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes("UTF-8")));
+        when(entity.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
         when(sl.getStatusCode()).thenReturn(statusCode);
         when(response.getStatusLine()).thenReturn(sl);
         when(response.getEntity()).thenReturn(entity);
@@ -112,7 +113,7 @@ public class SnsClientTest {
                     "447777111222"
             ));
             fail("An error Http response should raise IOException");
-        } catch (IOException ioe) {
+        } catch (NexmoResponseParseException nrp) {
             // This is expected
         }
     }

--- a/src/test/java/com/nexmo/client/verify/VerifyClientVerifyEndpointTest.java
+++ b/src/test/java/com/nexmo/client/verify/VerifyClientVerifyEndpointTest.java
@@ -22,10 +22,10 @@
 package com.nexmo.client.verify;
 
 import com.nexmo.client.ClientTest;
+import com.nexmo.client.NexmoResponseParseException;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
@@ -128,7 +128,7 @@ public class VerifyClientVerifyEndpointTest extends ClientTest<VerifyClient> {
         try {
             client.verify("447700900999", "TestBrand", "15555215554", 6, Locale.US);
             fail("An IOException should be thrown if an HTTP 500 response is received.");
-        } catch (IOException ioe) {
+        } catch (NexmoResponseParseException nrp) {
             // This is expected
         }
     }


### PR DESCRIPTION
Historically (aka before I started maintaining the server SDK) the `NexmoClientException` extended `Exception` which made it a checked exception. This PR converts `NexmoClientException` to an unchecked exception so that it no longer needs to be caught by the user.

This does not mean that you can no longer catch it, it still functions like any other exception. However, the compiler will no longer enforce try/catching the exception. I feel that this is a change that will help improve the "feel" of using the client.

I have kept the JavaDocs in around each of the sub-client methods, and they still declare that they will throw both a `NexmoClientException` and a `NexmoResponseParseException`. The `NexmoResponseParseException` is used to wrap the `IOException` that can come from parsing the input stream from the API response. It more accurately reflects the state at which it is thrown, and it is an unchecked exception.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
